### PR TITLE
`0.2.x`: plug back into upstream `ibc-proto`

### DIFF
--- a/ci/no-std-check/Cargo.toml
+++ b/ci/no-std-check/Cargo.toml
@@ -9,7 +9,7 @@ ibc-types = { path = "../../crates/ibc-types", default-features = false, feature
   "serde",
   "mocks-no-std",
 ] }
-ibc-proto = { version = "0.31.0-alpha.1", default-features = false, features = [
+ibc-proto = { version = "=0.31.0-alpha.1", default-features = false, features = [
   "parity-scale-codec",
   "borsh",
 ] }

--- a/ci/no-std-check/Cargo.toml
+++ b/ci/no-std-check/Cargo.toml
@@ -9,7 +9,7 @@ ibc-types = { path = "../../crates/ibc-types", default-features = false, feature
   "serde",
   "mocks-no-std",
 ] }
-ibc-proto = { git = "https://github.com/penumbra-zone/ibc-proto-rs", branch = "penumbra", version = "0.30.0", default-features = false, features = [
+ibc-proto = { version = "0.31.0-alpha.1", default-features = false, features = [
   "parity-scale-codec",
   "borsh",
 ] }

--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -56,7 +56,7 @@ mocks-no-std = ["cfg-if"]
 ibc-types-timestamp = { version = "0.2.0", path = "../ibc-types-timestamp", default-features = false }
 ibc-types-domain-type = { version = "0.2.0", path = "../ibc-types-domain-type", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.31.0-alpha.1", default-features = false, features = ["parity-scale-codec", "borsh"] }
+ibc-proto = { version = "=0.31.0-alpha.1", default-features = false, features = ["parity-scale-codec", "borsh"] }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }

--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -56,7 +56,7 @@ mocks-no-std = ["cfg-if"]
 ibc-types-timestamp = { version = "0.2.0", path = "../ibc-types-timestamp", default-features = false }
 ibc-types-domain-type = { version = "0.2.0", path = "../ibc-types-domain-type", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { git = "https://github.com/penumbra-zone/ibc-proto-rs", branch = "penumbra",version = "0.30.0", default-features = false, features = ["parity-scale-codec", "borsh"] }
+ibc-proto = { version = "0.31.0-alpha.1", default-features = false, features = ["parity-scale-codec", "borsh"] }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }

--- a/crates/ibc-types-lightclients-tendermint/Cargo.toml
+++ b/crates/ibc-types-lightclients-tendermint/Cargo.toml
@@ -53,7 +53,7 @@ mocks-no-std = ["cfg-if"]
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.31.0-alpha.1", default-features = false, features = ["parity-scale-codec", "borsh"] }
+ibc-proto = { version = "=0.31.0-alpha.1", default-features = false, features = ["parity-scale-codec", "borsh"] }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }

--- a/crates/ibc-types-lightclients-tendermint/Cargo.toml
+++ b/crates/ibc-types-lightclients-tendermint/Cargo.toml
@@ -81,20 +81,20 @@ parking_lot = { version = "0.12.1", default-features = false, optional = true }
 cfg-if = { version = "1.0.0", optional = true }
 
 [dependencies.tendermint]
-version = "0.29"
+version = "0.31.1"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.29"
+version = "0.31.1"
 default-features = false
 
 [dependencies.tendermint-light-client-verifier]
-version = "0.29"
+version = "0.31.1"
 default-features = false
 features = ["rust-crypto"]
 
 [dependencies.tendermint-testgen]
-version = "0.29"
+version = "0.31.1"
 optional = true
 default-features = false
 

--- a/crates/ibc-types-lightclients-tendermint/Cargo.toml
+++ b/crates/ibc-types-lightclients-tendermint/Cargo.toml
@@ -53,7 +53,7 @@ mocks-no-std = ["cfg-if"]
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { git = "https://github.com/penumbra-zone/ibc-proto-rs", branch = "penumbra", version = "0.30.0", default-features = false, features = ["parity-scale-codec", "borsh"] }
+ibc-proto = { version = "0.31.0-alpha.1", default-features = false, features = ["parity-scale-codec", "borsh"] }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }

--- a/crates/ibc-types-timestamp/Cargo.toml
+++ b/crates/ibc-types-timestamp/Cargo.toml
@@ -76,20 +76,20 @@ parking_lot = { version = "0.12.1", default-features = false, optional = true }
 cfg-if = { version = "1.0.0", optional = true }
 
 [dependencies.tendermint]
-version = "0.29"
+version = "0.31.1"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.29"
+version = "0.31.1"
 default-features = false
 
 [dependencies.tendermint-light-client-verifier]
-version = "0.29"
+version = "0.31.1"
 default-features = false
 features = ["rust-crypto"]
 
 [dependencies.tendermint-testgen]
-version = "0.29"
+version = "0.31.1"
 optional = true
 default-features = false
 

--- a/crates/ibc-types-timestamp/Cargo.toml
+++ b/crates/ibc-types-timestamp/Cargo.toml
@@ -48,7 +48,7 @@ mocks-no-std = ["cfg-if"]
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.31.0-alpha.1", default-features = false, features = ["parity-scale-codec", "borsh"] }
+ibc-proto = { version = "=0.31.0-alpha.1", default-features = false, features = ["parity-scale-codec", "borsh"] }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }

--- a/crates/ibc-types-timestamp/Cargo.toml
+++ b/crates/ibc-types-timestamp/Cargo.toml
@@ -48,7 +48,7 @@ mocks-no-std = ["cfg-if"]
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { git = "https://github.com/penumbra-zone/ibc-proto-rs", branch = "penumbra",version = "0.30.0", default-features = false, features = ["parity-scale-codec", "borsh"] }
+ibc-proto = { version = "0.31.0-alpha.1", default-features = false, features = ["parity-scale-codec", "borsh"] }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }

--- a/crates/ibc-types/Cargo.toml
+++ b/crates/ibc-types/Cargo.toml
@@ -53,7 +53,7 @@ mocks-no-std = ["cfg-if"]
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.31.0-alpha.1", default-features = false, features = ["parity-scale-codec", "borsh"] }
+ibc-proto = { version = "=0.31.0-alpha.1", default-features = false, features = ["parity-scale-codec", "borsh"] }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }

--- a/crates/ibc-types/Cargo.toml
+++ b/crates/ibc-types/Cargo.toml
@@ -53,7 +53,7 @@ mocks-no-std = ["cfg-if"]
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { git = "https://github.com/penumbra-zone/ibc-proto-rs", branch = "penumbra", version = "0.30.0", default-features = false, features = ["parity-scale-codec", "borsh"] }
+ibc-proto = { version = "0.31.0-alpha.1", default-features = false, features = ["parity-scale-codec", "borsh"] }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }


### PR DESCRIPTION
Closes #3 