### PR TITLE
build: remove unused deps

### DIFF
--- a/crates/ibc-types-core-channel/Cargo.toml
+++ b/crates/ibc-types-core-channel/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 
 [features]
 default = ["std"]
-std = [ 
+std = [
     "ibc-types-timestamp/std",
     "ibc-types-identifier/std",
     "ibc-types-core-client/std",
@@ -28,7 +28,6 @@ std = [
     "ics23/std",
     "serde/std",
     "serde_json/std",
-    "erased-serde/std",
     "tracing/std",
     "prost/std",
     "bytes/std",
@@ -36,8 +35,6 @@ std = [
     "sha2/std",
     "displaydoc/std",
     "num-traits/std",
-    "uint/std",
-    "primitive-types/std",
     "tendermint/clock",
     "tendermint/std",
 ]
@@ -45,7 +42,7 @@ parity-scale-codec = ["dep:parity-scale-codec", "dep:scale-info"]
 borsh = ["dep:borsh"]
 
 # This feature is required for token transfer (ICS-20)
-serde = ["dep:serde", "dep:serde_derive", "serde_json", "erased-serde"]
+serde = ["dep:serde", "dep:serde_derive", "serde_json"]
 
 # This feature guards the unfinished implementation of the `UpgradeClient` handler.
 upgrade_client = []
@@ -56,38 +53,34 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-ibc-types-timestamp = { version = "0.2.0", path = "../ibc-types-timestamp", default-features = false }
-ibc-types-identifier = { version = "0.2.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-domain-type = { version = "0.2.0", path = "../ibc-types-domain-type", default-features = false }
 ibc-types-core-client = { version = "0.2.0", path = "../ibc-types-core-client", default-features = false }
 ibc-types-core-connection = { version = "0.2.0", path = "../ibc-types-core-connection", default-features = false }
+ibc-types-domain-type = { version = "0.2.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-identifier = { version = "0.2.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-timestamp = { version = "0.2.0", path = "../ibc-types-timestamp", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
 ibc-proto = { git = "https://github.com/penumbra-zone/ibc-proto-rs", branch = "penumbra",version = "0.30.0", default-features = false, features = ["parity-scale-codec", "borsh"] }
-ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
-time = { version = ">=0.3.0, <0.3.20", default-features = false }
-serde_derive = { version = "1.0.104", default-features = false, optional = true }
-serde = { version = "1.0", default-features = false, optional = true }
-serde_json = { version = "1", default-features = false, optional = true }
-erased-serde = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
-tracing = { version = "0.1.36", default-features = false }
-prost = { version = "0.11", default-features = false }
-bytes = { version = "1.2.1", default-features = false }
-safe-regex = { version = "0.2.5", default-features = false }
-subtle-encoding = { version = "0.5", default-features = false }
-sha2 = { version = "0.10.6", default-features = false }
-displaydoc = { version = "0.2", default-features = false }
-num-traits = { version = "0.2.15", default-features = false }
-derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
-uint = { version = "0.9", default-features = false }
-primitive-types = { version = "0.12.0", default-features = false, features = ["serde_no_std"] }
-dyn-clone = "1.0.8"
-## for codec encode or decode
-parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
 ## for borsh encode or decode
 borsh = {version = "0.10.0", default-features = false, optional = true }
-parking_lot = { version = "0.12.1", default-features = false, optional = true }
+bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
+derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
+displaydoc = { version = "0.2", default-features = false }
+ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
+num-traits = { version = "0.2.15", default-features = false }
+## for codec encode or decode
+parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
+parking_lot = { version = "0.12.1", default-features = false, optional = true }
+prost = { version = "0.11", default-features = false }
+safe-regex = { version = "0.2.5", default-features = false }
+serde = { version = "1.0", default-features = false, optional = true }
+serde_derive = { version = "1.0.104", default-features = false, optional = true }
+serde_json = { version = "1", default-features = false, optional = true }
+sha2 = { version = "0.10.6", default-features = false }
+subtle-encoding = { version = "0.5", default-features = false }
+time = { version = ">=0.3.0, <0.3.20", default-features = false }
+tracing = { version = "0.1.36", default-features = false }
+scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
 
 [dependencies.tendermint]
 version = "0.31.1"
@@ -97,24 +90,14 @@ default-features = false
 version = "0.31.1"
 default-features = false
 
-[dependencies.tendermint-light-client-verifier]
-version = "0.31.1"
-default-features = false
-features = ["rust-crypto"]
-
 [dependencies.tendermint-testgen]
 version = "0.31.1"
 optional = true
 default-features = false
 
 [dev-dependencies]
-env_logger = "0.10.0"
-rstest = "0.16.0"
-tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
-test-log = { version = "0.2.10", features = ["trace"] }
-tendermint-rpc = { version = "0.31.1", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { version = "0.31.1" } # Needed for generating (synthetic) light blocks.
-parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }
-
+env_logger = "0.10.0"
 ibc-types-core-client = { version = "0.2.0", path = "../ibc-types-core-client", features = ["mocks"] }
+test-log = { version = "0.2.10", features = ["trace"] }
+tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}

--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -19,23 +19,19 @@ all-features = true
 
 [features]
 default = ["std"]
-std = [ 
-    "ibc-types-timestamp/std",
-    "ibc-types-identifier/std",
+std = [
+    "bytes/std",
+    "displaydoc/std",
     "ibc-proto/std",
+    "ibc-types-identifier/std",
+    "ibc-types-timestamp/std",
     "ics23/std",
+    "num-traits/std",
+    "prost/std",
     "serde/std",
     "serde_json/std",
-    "erased-serde/std",
-    "tracing/std",
-    "prost/std",
-    "bytes/std",
-    "subtle-encoding/std",
     "sha2/std",
-    "displaydoc/std",
-    "num-traits/std",
-    "uint/std",
-    "primitive-types/std",
+    "subtle-encoding/std",
     "tendermint/clock",
     "tendermint/std",
 ]
@@ -43,48 +39,37 @@ parity-scale-codec = ["dep:parity-scale-codec", "dep:scale-info"]
 borsh = ["dep:borsh"]
 
 # This feature is required for token transfer (ICS-20)
-serde = ["dep:serde", "dep:serde_derive", "serde_json", "erased-serde"]
+serde = ["dep:serde", "dep:serde_derive", "serde_json"]
 
 # This feature guards the unfinished implementation of the `UpgradeClient` handler.
 upgrade_client = []
 
 # This feature grants access to development-time mocking libraries, such as `MockContext` or `MockHeader`.
 # Depends on the `testgen` suite for generating Tendermint light blocks.
-mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
+mocks = ["tendermint/clock", "cfg-if"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-ibc-types-timestamp = { version = "0.2.0", path = "../ibc-types-timestamp", default-features = false }
-ibc-types-identifier = { version = "0.2.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-domain-type = { version = "0.2.0", path = "../ibc-types-domain-type", default-features = false }
-# Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { git = "https://github.com/penumbra-zone/ibc-proto-rs", branch = "penumbra",version = "0.30.0", default-features = false, features = ["parity-scale-codec", "borsh"] }
-ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
-time = { version = ">=0.3.0, <0.3.20", default-features = false }
-serde_derive = { version = "1.0.104", default-features = false, optional = true }
-serde = { version = "1.0", default-features = false, optional = true }
-serde_json = { version = "1", default-features = false, optional = true }
-erased-serde = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
-tracing = { version = "0.1.36", default-features = false }
-prost = { version = "0.11", default-features = false }
-bytes = { version = "1.2.1", default-features = false }
-safe-regex = { version = "0.2.5", default-features = false }
-subtle-encoding = { version = "0.5", default-features = false }
-sha2 = { version = "0.10.6", default-features = false }
-displaydoc = { version = "0.2", default-features = false }
-num-traits = { version = "0.2.15", default-features = false }
-derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
-uint = { version = "0.9", default-features = false }
-primitive-types = { version = "0.12.0", default-features = false, features = ["serde_no_std"] }
-dyn-clone = "1.0.8"
-## for codec encode or decode
-parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
-## for borsh encode or decode
 borsh = {version = "0.10.0", default-features = false, optional = true }
-parking_lot = { version = "0.12.1", default-features = false, optional = true }
+bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
-anyhow = "1"
+derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
+displaydoc = { version = "0.2", default-features = false }
+ibc-proto = { git = "https://github.com/penumbra-zone/ibc-proto-rs", branch = "penumbra",version = "0.30.0", default-features = false, features = ["parity-scale-codec", "borsh"] }
+ibc-types-domain-type = { version = "0.2.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-identifier = { version = "0.2.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-timestamp = { version = "0.2.0", path = "../ibc-types-timestamp", default-features = false }
+ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
+num-traits = { version = "0.2.15", default-features = false }
+parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
+prost = { version = "0.11", default-features = false }
+scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
+serde = { version = "1.0", default-features = false, optional = true }
+serde_derive = { version = "1.0.104", default-features = false, optional = true }
+serde_json = { version = "1", default-features = false, optional = true }
+sha2 = { version = "0.10.6", default-features = false }
+subtle-encoding = { version = "0.5", default-features = false }
+time = { version = ">=0.3.0, <0.3.20", default-features = false }
 
 [dependencies.tendermint]
 version = "0.31.1"
@@ -94,23 +79,6 @@ default-features = false
 version = "0.31.1"
 default-features = false
 
-[dependencies.tendermint-light-client-verifier]
-version = "0.31.1"
-default-features = false
-features = ["rust-crypto"]
-
-[dependencies.tendermint-testgen]
-version = "0.31.1"
-optional = true
-default-features = false
-
 [dev-dependencies]
-env_logger = "0.10.0"
-rstest = "0.16.0"
-tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
-test-log = { version = "0.2.10", features = ["trace"] }
-tendermint-rpc = { version = "0.31.1", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { version = "0.31.1" } # Needed for generating (synthetic) light blocks.
-parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }
 

--- a/crates/ibc-types-core-commitment/src/error.rs
+++ b/crates/ibc-types-core-commitment/src/error.rs
@@ -4,7 +4,10 @@ use displaydoc::Display;
 
 /// A catch-all error type.
 #[derive(Debug, Display)]
-pub enum Error {}
+pub enum Error {
+    /// Unused.
+    Unused,
+}
 
 #[cfg(feature = "std")]
 impl std::error::Error for Error {

--- a/crates/ibc-types-core-connection/Cargo.toml
+++ b/crates/ibc-types-core-connection/Cargo.toml
@@ -19,24 +19,20 @@ all-features = true
 
 [features]
 default = ["std"]
-std = [ 
-    "ibc-types-timestamp/std",
-    "ibc-types-identifier/std",
-    "ibc-types-core-client/std",
+std = [
+    "bytes/std",
+    "displaydoc/std",
     "ibc-proto/std",
+    "ibc-types-core-client/std",
+    "ibc-types-identifier/std",
+    "ibc-types-timestamp/std",
     "ics23/std",
+    "num-traits/std",
+    "prost/std",
     "serde/std",
     "serde_json/std",
-    "erased-serde/std",
-    "tracing/std",
-    "prost/std",
-    "bytes/std",
-    "subtle-encoding/std",
     "sha2/std",
-    "displaydoc/std",
-    "num-traits/std",
-    "uint/std",
-    "primitive-types/std",
+    "subtle-encoding/std",
     "tendermint/clock",
     "tendermint/std",
 ]
@@ -44,7 +40,7 @@ parity-scale-codec = ["dep:parity-scale-codec", "dep:scale-info"]
 borsh = ["dep:borsh"]
 
 # This feature is required for token transfer (ICS-20)
-serde = ["dep:serde", "dep:serde_derive", "serde_json", "erased-serde"]
+serde = ["dep:serde", "dep:serde_derive", "serde_json"]
 
 # This feature guards the unfinished implementation of the `UpgradeClient` handler.
 upgrade_client = []
@@ -59,33 +55,25 @@ ibc-types-timestamp = { version = "0.2.0", path = "../ibc-types-timestamp", defa
 ibc-types-identifier = { version = "0.2.0", path = "../ibc-types-identifier", default-features = false }
 ibc-types-domain-type = { version = "0.2.0", path = "../ibc-types-domain-type", default-features = false }
 ibc-types-core-client = { version = "0.2.0", path = "../ibc-types-core-client", default-features = false }
-# Proto definitions for all IBC-related interfaces, e.g., connections or channels.
+borsh = {version = "0.10.0", default-features = false, optional = true }
+bytes = { version = "1.2.1", default-features = false }
+cfg-if = { version = "1.0.0", optional = true }
+derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
+displaydoc = { version = "0.2", default-features = false }
 ibc-proto = { git = "https://github.com/penumbra-zone/ibc-proto-rs", branch = "penumbra",version = "0.30.0", default-features = false, features = ["parity-scale-codec", "borsh"] }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
-time = { version = ">=0.3.0, <0.3.20", default-features = false }
-serde_derive = { version = "1.0.104", default-features = false, optional = true }
-serde = { version = "1.0", default-features = false, optional = true }
-serde_json = { version = "1", default-features = false, optional = true }
-erased-serde = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
-tracing = { version = "0.1.36", default-features = false }
-prost = { version = "0.11", default-features = false }
-bytes = { version = "1.2.1", default-features = false }
-safe-regex = { version = "0.2.5", default-features = false }
-subtle-encoding = { version = "0.5", default-features = false }
-sha2 = { version = "0.10.6", default-features = false }
-displaydoc = { version = "0.2", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
-derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
-uint = { version = "0.9", default-features = false }
-primitive-types = { version = "0.12.0", default-features = false, features = ["serde_no_std"] }
-dyn-clone = "1.0.8"
-## for codec encode or decode
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
-## for borsh encode or decode
-borsh = {version = "0.10.0", default-features = false, optional = true }
 parking_lot = { version = "0.12.1", default-features = false, optional = true }
-cfg-if = { version = "1.0.0", optional = true }
+prost = { version = "0.11", default-features = false }
+safe-regex = { version = "0.2.5", default-features = false }
+scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
+serde = { version = "1.0", default-features = false, optional = true }
+serde_derive = { version = "1.0.104", default-features = false, optional = true }
+serde_json = { version = "1", default-features = false, optional = true }
+sha2 = { version = "0.10.6", default-features = false }
+subtle-encoding = { version = "0.5", default-features = false }
+time = { version = ">=0.3.0, <0.3.20", default-features = false }
 
 [dependencies.tendermint]
 version = "0.31.1"
@@ -95,11 +83,6 @@ default-features = false
 version = "0.31.1"
 default-features = false
 
-[dependencies.tendermint-light-client-verifier]
-version = "0.31.1"
-default-features = false
-features = ["rust-crypto"]
-
 [dependencies.tendermint-testgen]
 version = "0.31.1"
 optional = true
@@ -107,12 +90,8 @@ default-features = false
 
 [dev-dependencies]
 env_logger = "0.10.0"
-rstest = "0.16.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
 test-log = { version = "0.2.10", features = ["trace"] }
-tendermint-rpc = { version = "0.31.1", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { version = "0.31.1" } # Needed for generating (synthetic) light blocks.
-parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }
-
 ibc-types-core-client = { version = "0.2.0", path = "../ibc-types-core-client", features = ["mocks"] }
+tracing = { version = "0.1.36", default-features = false }

--- a/crates/ibc-types-identifier/Cargo.toml
+++ b/crates/ibc-types-identifier/Cargo.toml
@@ -19,23 +19,9 @@ all-features = true
 
 [features]
 default = ["std"]
-std = [ 
-    "ibc-proto/std",
-    "ics23/std",
+std = [
     "serde/std",
-    "serde_json/std",
-    "erased-serde/std",
-    "tracing/std",
-    "prost/std",
-    "bytes/std",
-    "subtle-encoding/std",
-    "sha2/std",
     "displaydoc/std",
-    "num-traits/std",
-    "uint/std",
-    "primitive-types/std",
-    "tendermint/clock",
-    "tendermint/std",
 ]
 
 # This feature guards the unfinished implementation of the `UpgradeClient` handler.
@@ -43,30 +29,14 @@ upgrade_client = []
 
 # This feature grants access to development-time mocking libraries, such as `MockContext` or `MockHeader`.
 # Depends on the `testgen` suite for generating Tendermint light blocks.
-mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
+mocks = ["tendermint-testgen", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { git = "https://github.com/penumbra-zone/ibc-proto-rs", branch = "penumbra", version = "0.30.0", default-features = false, features = ["parity-scale-codec", "borsh"] }
-ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
-time = { version = ">=0.3.0, <0.3.20", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
-serde_json = { version = "1", default-features = false, optional = true }
-erased-serde = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
-tracing = { version = "0.1.36", default-features = false }
-prost = { version = "0.11", default-features = false }
-bytes = { version = "1.2.1", default-features = false }
-safe-regex = { version = "0.2.5", default-features = false }
-subtle-encoding = { version = "0.5", default-features = false }
-sha2 = { version = "0.10.6", default-features = false }
 displaydoc = { version = "0.2", default-features = false }
-num-traits = { version = "0.2.15", default-features = false }
-derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
-uint = { version = "0.9", default-features = false }
-primitive-types = { version = "0.12.0", default-features = false, features = ["serde_no_std"] }
-dyn-clone = "1.0.8"
 ## for codec encode or decode
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
@@ -75,31 +45,14 @@ borsh = {version = "0.10.0", default-features = false, optional = true }
 parking_lot = { version = "0.12.1", default-features = false, optional = true }
 cfg-if = { version = "1.0.0", optional = true }
 
-[dependencies.tendermint]
-version = "0.29"
-default-features = false
-
-[dependencies.tendermint-proto]
-version = "0.29"
-default-features = false
-
-[dependencies.tendermint-light-client-verifier]
-version = "0.29"
-default-features = false
-features = ["rust-crypto"]
-
 [dependencies.tendermint-testgen]
 version = "0.29"
 optional = true
 default-features = false
 
 [dev-dependencies]
-env_logger = "0.10.0"
-rstest = "0.16.0"
-tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
-test-log = { version = "0.2.10", features = ["trace"] }
-tendermint-rpc = { version = "0.31.1", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { version = "0.31.1" } # Needed for generating (synthetic) light blocks.
-parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }
-
+env_logger = "0.10.0"
+test-log = { version = "0.2.10", features = ["trace"] }
+tracing = { version = "0.1.36", default-features = false }
+tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}

--- a/crates/ibc-types-timestamp/Cargo.toml
+++ b/crates/ibc-types-timestamp/Cargo.toml
@@ -19,21 +19,14 @@ all-features = true
 
 [features]
 default = ["std"]
-std = [ 
-    "ibc-proto/std",
-    "ics23/std",
-    "serde/std",
-    "serde_json/std",
-    "erased-serde/std",
-    "tracing/std",
-    "prost/std",
+std = [
     "bytes/std",
-    "subtle-encoding/std",
-    "sha2/std",
     "displaydoc/std",
     "num-traits/std",
-    "uint/std",
-    "primitive-types/std",
+    "prost/std",
+    "serde/std",
+    "serde_json/std",
+    "subtle-encoding/std",
     "tendermint/clock",
     "tendermint/std",
 ]
@@ -47,33 +40,20 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-# Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { git = "https://github.com/penumbra-zone/ibc-proto-rs", branch = "penumbra",version = "0.30.0", default-features = false, features = ["parity-scale-codec", "borsh"] }
-ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
-time = { version = ">=0.3.0, <0.3.20", default-features = false }
-serde_derive = { version = "1.0.104", default-features = false, optional = true }
-serde = { version = "1.0", default-features = false, optional = true }
-serde_json = { version = "1", default-features = false, optional = true }
-erased-serde = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
-tracing = { version = "0.1.36", default-features = false }
-prost = { version = "0.11", default-features = false }
+borsh = {version = "0.10.0", default-features = false, optional = true }
 bytes = { version = "1.2.1", default-features = false }
-safe-regex = { version = "0.2.5", default-features = false }
-subtle-encoding = { version = "0.5", default-features = false }
-sha2 = { version = "0.10.6", default-features = false }
+cfg-if = { version = "1.0.0", optional = true }
 displaydoc = { version = "0.2", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
-derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
-uint = { version = "0.9", default-features = false }
-primitive-types = { version = "0.12.0", default-features = false, features = ["serde_no_std"] }
-dyn-clone = "1.0.8"
-## for codec encode or decode
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
-## for borsh encode or decode
-borsh = {version = "0.10.0", default-features = false, optional = true }
 parking_lot = { version = "0.12.1", default-features = false, optional = true }
-cfg-if = { version = "1.0.0", optional = true }
+prost = { version = "0.11", default-features = false }
+scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
+serde = { version = "1.0", default-features = false, optional = true }
+serde_derive = { version = "1.0.104", default-features = false, optional = true }
+serde_json = { version = "1", default-features = false, optional = true }
+subtle-encoding = { version = "0.5", default-features = false }
+time = { version = ">=0.3.0, <0.3.20", default-features = false }
 
 [dependencies.tendermint]
 version = "0.29"
@@ -83,23 +63,14 @@ default-features = false
 version = "0.29"
 default-features = false
 
-[dependencies.tendermint-light-client-verifier]
-version = "0.29"
-default-features = false
-features = ["rust-crypto"]
-
 [dependencies.tendermint-testgen]
 version = "0.29"
 optional = true
 default-features = false
 
 [dev-dependencies]
-env_logger = "0.10.0"
-rstest = "0.16.0"
-tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
-test-log = { version = "0.2.10", features = ["trace"] }
-tendermint-rpc = { version = "0.31.1", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { version = "0.31.1" } # Needed for generating (synthetic) light blocks.
-parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }
-
+env_logger = "0.10.0"
+test-log = { version = "0.2.10", features = ["trace"] }
+tracing = { version = "0.1.36", default-features = false }
+tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}

--- a/crates/ibc-types/Cargo.toml
+++ b/crates/ibc-types/Cargo.toml
@@ -19,23 +19,23 @@ all-features = true
 
 [features]
 default = ["std"]
-std = [ 
+std = [
+    "bytes/std",
+    "displaydoc/std",
+    "erased-serde/std",
     "ibc-proto/std",
     "ics23/std",
+    "num-traits/std",
+    "primitive-types/std",
+    "prost/std",
     "serde/std",
     "serde_json/std",
-    "erased-serde/std",
-    "tracing/std",
-    "prost/std",
-    "bytes/std",
-    "subtle-encoding/std",
     "sha2/std",
-    "displaydoc/std",
-    "num-traits/std",
-    "uint/std",
-    "primitive-types/std",
+    "subtle-encoding/std",
     "tendermint/clock",
     "tendermint/std",
+    "tracing/std",
+    "uint/std",
 ]
 parity-scale-codec = ["dep:parity-scale-codec", "dep:scale-info"]
 borsh = ["dep:borsh"]
@@ -52,33 +52,30 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-# Proto definitions for all IBC-related interfaces, e.g., connections or channels.
+borsh = {version = "0.10.0", default-features = false, optional = true }
+bytes = { version = "1.2.1", default-features = false }
+cfg-if = { version = "1.0.0", optional = true }
+derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
+displaydoc = { version = "0.2", default-features = false }
+dyn-clone = "1.0.8"
+erased-serde = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
 ibc-proto = { git = "https://github.com/penumbra-zone/ibc-proto-rs", branch = "penumbra", version = "0.30.0", default-features = false, features = ["parity-scale-codec", "borsh"] }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
-time = { version = ">=0.3.0, <0.3.20", default-features = false }
-serde_derive = { version = "1.0.104", default-features = false, optional = true }
-serde = { version = "1.0", default-features = false, optional = true }
-serde_json = { version = "1", default-features = false, optional = true }
-erased-serde = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
-tracing = { version = "0.1.36", default-features = false }
-prost = { version = "0.11", default-features = false }
-bytes = { version = "1.2.1", default-features = false }
-safe-regex = { version = "0.2.5", default-features = false }
-subtle-encoding = { version = "0.5", default-features = false }
-sha2 = { version = "0.10.6", default-features = false }
-displaydoc = { version = "0.2", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
-derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
-uint = { version = "0.9", default-features = false }
-primitive-types = { version = "0.12.0", default-features = false, features = ["serde_no_std"] }
-dyn-clone = "1.0.8"
-## for codec encode or decode
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
-scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
-## for borsh encode or decode
-borsh = {version = "0.10.0", default-features = false, optional = true }
 parking_lot = { version = "0.12.1", default-features = false, optional = true }
-cfg-if = { version = "1.0.0", optional = true }
+primitive-types = { version = "0.12.0", default-features = false, features = ["serde_no_std"] }
+prost = { version = "0.11", default-features = false }
+safe-regex = { version = "0.2.5", default-features = false }
+scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
+serde = { version = "1.0", default-features = false, optional = true }
+serde_derive = { version = "1.0.104", default-features = false, optional = true }
+serde_json = { version = "1", default-features = false, optional = true }
+sha2 = { version = "0.10.6", default-features = false }
+subtle-encoding = { version = "0.5", default-features = false }
+time = { version = ">=0.3.0, <0.3.20", default-features = false }
+tracing = { version = "0.1.36", default-features = false }
+uint = { version = "0.9", default-features = false }
 
 [dependencies.tendermint]
 version = "0.31.1"
@@ -99,11 +96,11 @@ optional = true
 default-features = false
 
 [dev-dependencies]
+cfg-if = { version = "1.0.0" }
 env_logger = "0.10.0"
+parking_lot = { version = "0.12.1" }
 rstest = "0.16.0"
-tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
-test-log = { version = "0.2.10", features = ["trace"] }
 tendermint-rpc = { version = "0.31.1", features = ["http-client", "websocket-client"] }
 tendermint-testgen = { version = "0.31.1" } # Needed for generating (synthetic) light blocks.
-parking_lot = { version = "0.12.1" }
-cfg-if = { version = "1.0.0" }
+test-log = { version = "0.2.10", features = ["trace"] }
+tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}

--- a/crates/ibc-types/src/lib.rs
+++ b/crates/ibc-types/src/lib.rs
@@ -2,14 +2,6 @@
 // https://github.com/informalsystems/ibc-rs/issues/987
 // #![cfg_attr(not(test), deny(clippy::unwrap_used))]
 #![no_std]
-#![deny(
-    warnings,
-    trivial_casts,
-    trivial_numeric_casts,
-    unused_import_braces,
-    rust_2018_idioms
-)]
-#![forbid(unsafe_code)]
 // https://github.com/cosmos/ibc-rs/issues/342
 #![allow(clippy::result_large_err)]
 //! This library provides data types for the InterBlockchain Communication (IBC) protocol in Rust.


### PR DESCRIPTION
Used the usual `cargo +nightly udeps --all-targets` to identify unused dependencies. Had to temporarily patch `crates/ibc-types/src/lib.rs` to remove the deny warnings directive, otherwise the command wouldn't succeed.

Closes #6.