### PR TITLE
cargo: use `tendermint@0.33` and prepare `v0.4.0`

### DIFF
--- a/ci/no-std-check/Cargo.toml
+++ b/ci/no-std-check/Cargo.toml
@@ -10,9 +10,9 @@ ibc-types = { path = "../../crates/ibc-types", default-features = false, feature
   "mocks-no-std",
 ] }
 ibc-proto = { version = "0.31.0", default-features = false }
-tendermint = { version = "0.32.0", default-features = false }
-tendermint-proto = { version = "0.32.0", default-features = false }
-tendermint-light-client-verifier = { version = "0.32.0", default-features = false, features = ["rust-crypto"] }
+tendermint = { version = "0.33.0", default-features = false }
+tendermint-proto = { version = "0.33.0", default-features = false }
+tendermint-light-client-verifier = { version = "0.33.0", default-features = false, features = ["rust-crypto"] }
 
 sp-core = { version = "17.0.0", default-features = false, optional = true }
 sp-io = { version = "18.0.0", default-features = false, optional = true }

--- a/ci/no-std-check/Cargo.toml
+++ b/ci/no-std-check/Cargo.toml
@@ -9,7 +9,7 @@ ibc-types = { path = "../../crates/ibc-types", default-features = false, feature
   "serde",
   "mocks-no-std",
 ] }
-ibc-proto = { version = "0.31.0", default-features = false }
+ibc-proto = { version = "0.33.0", default-features = false }
 tendermint = { version = "0.33.0", default-features = false }
 tendermint-proto = { version = "0.33.0", default-features = false }
 tendermint-light-client-verifier = { version = "0.33.0", default-features = false, features = ["rust-crypto"] }

--- a/crates/ibc-types-core-channel/Cargo.toml
+++ b/crates/ibc-types-core-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-core-channel"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
@@ -53,12 +53,12 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-ibc-types-core-client = { version = "0.3.0", path = "../ibc-types-core-client", default-features = false }
-ibc-types-core-connection = { version = "0.3.0", path = "../ibc-types-core-connection", default-features = false }
-ibc-types-core-commitment = { version = "0.3.0", path = "../ibc-types-core-commitment", default-features = false }
-ibc-types-domain-type = { version = "0.3.0", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-identifier = { version = "0.3.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-timestamp = { version = "0.3.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-core-client = { version = "0.4.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-core-connection = { version = "0.4.0", path = "../ibc-types-core-connection", default-features = false }
+ibc-types-core-commitment = { version = "0.4.0", path = "../ibc-types-core-commitment", default-features = false }
+ibc-types-domain-type = { version = "0.4.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-identifier = { version = "0.4.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-timestamp = { version = "0.4.0", path = "../ibc-types-timestamp", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
 ibc-proto = { version = "0.33.0", default-features = false }
 ## for borsh encode or decode
@@ -100,6 +100,6 @@ default-features = false
 [dev-dependencies]
 cfg-if = { version = "1.0.0" }
 env_logger = "0.10.0"
-ibc-types-core-client = { version = "0.3.0", path = "../ibc-types-core-client", features = ["mocks"] }
+ibc-types-core-client = { version = "0.4.0", path = "../ibc-types-core-client", features = ["mocks"] }
 test-log = { version = "0.2.10", features = ["trace"] }
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}

--- a/crates/ibc-types-core-channel/Cargo.toml
+++ b/crates/ibc-types-core-channel/Cargo.toml
@@ -85,15 +85,15 @@ scale-info = { version = "2.1.2", default-features = false, features = ["derive"
 anyhow = { version = "1", default-features = false }
 
 [dependencies.tendermint]
-version = "0.32.0"
+version = "0.33.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.32.0"
+version = "0.33.0"
 default-features = false
 
 [dependencies.tendermint-testgen]
-version = "0.32.0"
+version = "0.33.0"
 optional = true
 default-features = false
 

--- a/crates/ibc-types-core-channel/Cargo.toml
+++ b/crates/ibc-types-core-channel/Cargo.toml
@@ -60,7 +60,7 @@ ibc-types-domain-type = { version = "0.3.0", path = "../ibc-types-domain-type", 
 ibc-types-identifier = { version = "0.3.0", path = "../ibc-types-identifier", default-features = false }
 ibc-types-timestamp = { version = "0.3.0", path = "../ibc-types-timestamp", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.31.0", default-features = false }
+ibc-proto = { version = "0.33.0", default-features = false }
 ## for borsh encode or decode
 borsh = {version = "0.10.0", default-features = false, optional = true }
 bytes = { version = "1.2.1", default-features = false }

--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-core-client"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
@@ -55,9 +55,9 @@ cfg-if = { version = "1.0.0", optional = true }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 displaydoc = { version = "0.2", default-features = false }
 ibc-proto = { version = "0.33.0", default-features = false }
-ibc-types-domain-type = { version = "0.3.0", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-identifier = { version = "0.3.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-timestamp = { version = "0.3.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-domain-type = { version = "0.4.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-identifier = { version = "0.4.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-timestamp = { version = "0.4.0", path = "../ibc-types-timestamp", default-features = false }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }

--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -54,7 +54,7 @@ bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 displaydoc = { version = "0.2", default-features = false }
-ibc-proto = { version = "0.31.0", default-features = false }
+ibc-proto = { version = "0.33.0", default-features = false }
 ibc-types-domain-type = { version = "0.3.0", path = "../ibc-types-domain-type", default-features = false }
 ibc-types-identifier = { version = "0.3.0", path = "../ibc-types-identifier", default-features = false }
 ibc-types-timestamp = { version = "0.3.0", path = "../ibc-types-timestamp", default-features = false }

--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -72,11 +72,11 @@ time = { version = ">=0.3.0, <0.3.20", default-features = false }
 anyhow = { version = "1", default-features = false }
 
 [dependencies.tendermint]
-version = "0.32.0"
+version = "0.33.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.32.0"
+version = "0.33.0"
 default-features = false
 
 [dev-dependencies]

--- a/crates/ibc-types-core-commitment/Cargo.toml
+++ b/crates/ibc-types-core-commitment/Cargo.toml
@@ -87,20 +87,20 @@ cfg-if = { version = "1.0.0", optional = true }
 anyhow = "1"
 
 [dependencies.tendermint]
-version = "0.32.0"
+version = "0.33.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.32.0"
+version = "0.33.0"
 default-features = false
 
 [dependencies.tendermint-light-client-verifier]
-version = "0.32.0"
+version = "0.33.0"
 default-features = false
 features = ["rust-crypto"]
 
 [dependencies.tendermint-testgen]
-version = "0.32.0"
+version = "0.33.0"
 optional = true
 default-features = false
 
@@ -109,8 +109,8 @@ env_logger = "0.10.0"
 rstest = "0.16.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
 test-log = { version = "0.2.10", features = ["trace"] }
-tendermint-rpc = { version = "0.32.0", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { version = "0.32.0" } # Needed for generating (synthetic) light blocks.
+tendermint-rpc = { version = "0.33.0", features = ["http-client", "websocket-client"] }
+tendermint-testgen = { version = "0.33.0" } # Needed for generating (synthetic) light blocks.
 parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }
 

--- a/crates/ibc-types-core-commitment/Cargo.toml
+++ b/crates/ibc-types-core-commitment/Cargo.toml
@@ -58,7 +58,7 @@ ibc-types-timestamp = { version = "0.3.0", path = "../ibc-types-timestamp", defa
 ibc-types-identifier = { version = "0.3.0", path = "../ibc-types-identifier", default-features = false }
 ibc-types-domain-type = { version = "0.3.0", path = "../ibc-types-domain-type", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.31.0", default-features = false }
+ibc-proto = { version = "0.33.0", default-features = false }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }

--- a/crates/ibc-types-core-commitment/Cargo.toml
+++ b/crates/ibc-types-core-commitment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-core-commitment"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
@@ -54,9 +54,9 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-ibc-types-timestamp = { version = "0.3.0", path = "../ibc-types-timestamp", default-features = false }
-ibc-types-identifier = { version = "0.3.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-domain-type = { version = "0.3.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-timestamp = { version = "0.4.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-identifier = { version = "0.4.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-domain-type = { version = "0.4.0", path = "../ibc-types-domain-type", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
 ibc-proto = { version = "0.33.0", default-features = false }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }

--- a/crates/ibc-types-core-connection/Cargo.toml
+++ b/crates/ibc-types-core-connection/Cargo.toml
@@ -78,15 +78,15 @@ time = { version = ">=0.3.0, <0.3.20", default-features = false }
 anyhow = { version = "1", default-features = false }
 
 [dependencies.tendermint]
-version = "0.32.0"
+version = "0.33.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.32.0"
+version = "0.33.0"
 default-features = false
 
 [dependencies.tendermint-testgen]
-version = "0.32.0"
+version = "0.33.0"
 optional = true
 default-features = false
 

--- a/crates/ibc-types-core-connection/Cargo.toml
+++ b/crates/ibc-types-core-connection/Cargo.toml
@@ -61,7 +61,7 @@ bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 displaydoc = { version = "0.2", default-features = false }
-ibc-proto = { version = "0.31.0", default-features = false }
+ibc-proto = { version = "0.33.0", default-features = false }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }

--- a/crates/ibc-types-core-connection/Cargo.toml
+++ b/crates/ibc-types-core-connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-core-connection"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
@@ -51,11 +51,11 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-ibc-types-timestamp = { version = "0.3.0", path = "../ibc-types-timestamp", default-features = false }
-ibc-types-core-commitment = { version = "0.3.0", path = "../ibc-types-core-commitment", features = ["serde"], default-features = false }
-ibc-types-identifier = { version = "0.3.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-domain-type = { version = "0.3.0", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-core-client = { version = "0.3.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-timestamp = { version = "0.4.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-core-commitment = { version = "0.4.0", path = "../ibc-types-core-commitment", default-features = false }
+ibc-types-identifier = { version = "0.4.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-domain-type = { version = "0.4.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-core-client = { version = "0.4.0", path = "../ibc-types-core-client", default-features = false }
 borsh = {version = "0.10.0", default-features = false, optional = true }
 bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
@@ -95,5 +95,5 @@ env_logger = "0.10.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
 test-log = { version = "0.2.10", features = ["trace"] }
 cfg-if = { version = "1.0.0" }
-ibc-types-core-client = { version = "0.3.0", path = "../ibc-types-core-client", features = ["mocks"] }
+ibc-types-core-client = { version = "0.4.0", path = "../ibc-types-core-client", features = ["mocks"] }
 tracing = { version = "0.1.36", default-features = false }

--- a/crates/ibc-types-domain-type/Cargo.toml
+++ b/crates/ibc-types-domain-type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibc-types-domain-type"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license      = "Apache-2.0"
 publish = true

--- a/crates/ibc-types-identifier/Cargo.toml
+++ b/crates/ibc-types-identifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-identifier"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"

--- a/crates/ibc-types-identifier/Cargo.toml
+++ b/crates/ibc-types-identifier/Cargo.toml
@@ -47,7 +47,7 @@ parking_lot = { version = "0.12.1", default-features = false, optional = true }
 cfg-if = { version = "1.0.0", optional = true }
 
 [dependencies.tendermint-testgen]
-version = "0.29"
+version = "0.33"
 optional = true
 default-features = false
 

--- a/crates/ibc-types-lightclients-tendermint/Cargo.toml
+++ b/crates/ibc-types-lightclients-tendermint/Cargo.toml
@@ -92,20 +92,20 @@ cfg-if = { version = "1.0.0", optional = true }
 anyhow = { version = "1", default-features = false }
 
 [dependencies.tendermint]
-version = "0.32.0"
+version = "0.33.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.32.0"
+version = "0.33.0"
 default-features = false
 
 [dependencies.tendermint-light-client-verifier]
-version = "0.32.0"
+version = "0.33.0"
 default-features = false
 features = ["rust-crypto"]
 
 [dependencies.tendermint-testgen]
-version = "0.32.0"
+version = "0.33.0"
 optional = true
 default-features = false
 
@@ -114,8 +114,8 @@ env_logger = "0.10.0"
 rstest = "0.16.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
 test-log = { version = "0.2.10", features = ["trace"] }
-tendermint-rpc = { version = "0.32.0", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { version = "0.32.0" } # Needed for generating (synthetic) light blocks.
+tendermint-rpc = { version = "0.33.0", features = ["http-client", "websocket-client"] }
+tendermint-testgen = { version = "0.33.0" } # Needed for generating (synthetic) light blocks.
 parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }
 

--- a/crates/ibc-types-lightclients-tendermint/Cargo.toml
+++ b/crates/ibc-types-lightclients-tendermint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-lightclients-tendermint"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
@@ -56,12 +56,12 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-ibc-types-timestamp = { version = "0.3.0", path = "../ibc-types-timestamp", default-features = false }
-ibc-types-identifier = { version = "0.3.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-domain-type = { version = "0.3.0", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-core-client = { version = "0.3.0", path = "../ibc-types-core-client", default-features = false }
-ibc-types-core-connection = { version = "0.3.0", path = "../ibc-types-core-connection", default-features = false }
-ibc-types-core-commitment = { version = "0.3.0", path = "../ibc-types-core-commitment", default-features = false }
+ibc-types-timestamp = { version = "0.4.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-identifier = { version = "0.4.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-domain-type = { version = "0.4.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-core-client = { version = "0.4.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-core-connection = { version = "0.4.0", path = "../ibc-types-core-connection", default-features = false }
+ibc-types-core-commitment = { version = "0.4.0", path = "../ibc-types-core-commitment", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
 ibc-proto = { version = "0.33.0", default-features = false }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
@@ -119,4 +119,4 @@ tendermint-testgen = { version = "0.33.0" } # Needed for generating (synthetic) 
 parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }
 
-ibc-types-core-client = { version = "0.3.0", path = "../ibc-types-core-client", features = ["mocks"] }
+ibc-types-core-client = { version = "0.4.0", path = "../ibc-types-core-client", features = ["mocks"] }

--- a/crates/ibc-types-lightclients-tendermint/Cargo.toml
+++ b/crates/ibc-types-lightclients-tendermint/Cargo.toml
@@ -63,7 +63,7 @@ ibc-types-core-client = { version = "0.3.0", path = "../ibc-types-core-client", 
 ibc-types-core-connection = { version = "0.3.0", path = "../ibc-types-core-connection", default-features = false }
 ibc-types-core-commitment = { version = "0.3.0", path = "../ibc-types-core-commitment", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.31.0", default-features = false }
+ibc-proto = { version = "0.33.0", default-features = false }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }

--- a/crates/ibc-types-path/Cargo.toml
+++ b/crates/ibc-types-path/Cargo.toml
@@ -61,9 +61,9 @@ serde_derive = { version = "1.0.104", default-features = false, optional = true 
 serde_json = { version = "1", default-features = false, optional = true }
 subtle-encoding = { version = "0.5", default-features = false }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
-tendermint = { version = "0.32.0", default-features = false }
-tendermint-proto = { version = "0.32.0", default-features = false }
-tendermint-testgen = { version = "0.32.0", default-features = false, optional = true }
+tendermint = { version = "0.33.0", default-features = false }
+tendermint-proto = { version = "0.33.0", default-features = false }
+tendermint-testgen = { version = "0.33.0", default-features = false, optional = true }
 
 [dev-dependencies]
 cfg-if = { version = "1.0.0" }

--- a/crates/ibc-types-path/Cargo.toml
+++ b/crates/ibc-types-path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-path"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
@@ -44,9 +44,9 @@ mocks-no-std = ["cfg-if"]
 
 [dependencies]
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
-ibc-types-core-client = { version = "0.3.0", path = "../ibc-types-core-client", default-features = false }
-ibc-types-core-connection = { version = "0.3.0", path = "../ibc-types-core-connection", default-features = false }
-ibc-types-core-channel = { version = "0.3.0", path = "../ibc-types-core-channel", default-features = false }
+ibc-types-core-client = { version = "0.4.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-core-connection = { version = "0.4.0", path = "../ibc-types-core-connection", default-features = false }
+ibc-types-core-channel = { version = "0.4.0", path = "../ibc-types-core-channel", default-features = false }
 borsh = {version = "0.10.0", default-features = false, optional = true }
 bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }

--- a/crates/ibc-types-timestamp/Cargo.toml
+++ b/crates/ibc-types-timestamp/Cargo.toml
@@ -54,9 +54,9 @@ serde_derive = { version = "1.0.104", default-features = false, optional = true 
 serde_json = { version = "1", default-features = false, optional = true }
 subtle-encoding = { version = "0.5", default-features = false }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
-tendermint = { version = "0.32.0", default-features = false }
-tendermint-proto = { version = "0.32.0", default-features = false }
-tendermint-testgen = { version = "0.32.0", default-features = false, optional = true }
+tendermint = { version = "0.33.0", default-features = false }
+tendermint-proto = { version = "0.33.0", default-features = false }
+tendermint-testgen = { version = "0.33.0", default-features = false, optional = true }
 
 [dev-dependencies]
 cfg-if = { version = "1.0.0" }

--- a/crates/ibc-types-timestamp/Cargo.toml
+++ b/crates/ibc-types-timestamp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-timestamp"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"

--- a/crates/ibc-types-transfer/Cargo.toml
+++ b/crates/ibc-types-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-transfer"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"

--- a/crates/ibc-types-transfer/Cargo.toml
+++ b/crates/ibc-types-transfer/Cargo.toml
@@ -47,7 +47,7 @@ parking_lot = { version = "0.12.1", default-features = false, optional = true }
 cfg-if = { version = "1.0.0", optional = true }
 
 [dependencies.tendermint-testgen]
-version = "0.29"
+version = "0.33"
 optional = true
 default-features = false
 

--- a/crates/ibc-types/Cargo.toml
+++ b/crates/ibc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types"
-version      = "0.3.0"
+version      = "0.4.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
@@ -44,13 +44,13 @@ mocks = [
 ]
 
 [dependencies]
-ibc-types-timestamp = { version = "0.3.0", path = "../ibc-types-timestamp", default-features = false }
-ibc-types-identifier = { version = "0.3.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-domain-type = { version = "0.3.0", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-core-client = { version = "0.3.0", path = "../ibc-types-core-client", default-features = false }
-ibc-types-core-connection = { version = "0.3.0", path = "../ibc-types-core-connection", default-features = false }
-ibc-types-core-channel = { version = "0.3.0", path = "../ibc-types-core-channel", default-features = false }
-ibc-types-core-commitment = { version = "0.3.0", path = "../ibc-types-core-commitment", default-features = false }
-ibc-types-lightclients-tendermint = { version = "0.3.0", path = "../ibc-types-lightclients-tendermint", default-features = false }
-ibc-types-path = { version = "0.3.0", path = "../ibc-types-path", default-features = false }
-ibc-types-transfer = { version = "0.3.0", path = "../ibc-types-transfer", default-features = false }
+ibc-types-timestamp = { version = "0.4.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-identifier = { version = "0.4.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-domain-type = { version = "0.4.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-core-client = { version = "0.4.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-core-connection = { version = "0.4.0", path = "../ibc-types-core-connection", default-features = false }
+ibc-types-core-channel = { version = "0.4.0", path = "../ibc-types-core-channel", default-features = false }
+ibc-types-core-commitment = { version = "0.4.0", path = "../ibc-types-core-commitment", default-features = false }
+ibc-types-lightclients-tendermint = { version = "0.4.0", path = "../ibc-types-lightclients-tendermint", default-features = false }
+ibc-types-path = { version = "0.4.0", path = "../ibc-types-path", default-features = false }
+ibc-types-transfer = { version = "0.4.0", path = "../ibc-types-transfer", default-features = false }


### PR DESCRIPTION
This PR closes #39 : 
- bumps `tendermint-rs` to `0.33`
- bumps `ibc-proto` to `0.33`
- prepare release `v0.4.0`