### PR TITLE
ci: add dry-run phase and modify `with_serde` feature

### DIFF
--- a/crates/ibc-types-core-connection/Cargo.toml
+++ b/crates/ibc-types-core-connection/Cargo.toml
@@ -40,7 +40,7 @@ parity-scale-codec = ["dep:parity-scale-codec", "dep:scale-info"]
 borsh = ["dep:borsh"]
 
 # This feature is required for token transfer (ICS-20)
-serde = ["dep:serde", "dep:serde_derive", "serde_json"]
+with_serde = ["serde", "serde_derive", "serde_json"]
 
 # This feature guards the unfinished implementation of the `UpgradeClient` handler.
 upgrade_client = []

--- a/crates/ibc-types-core-connection/src/connection.rs
+++ b/crates/ibc-types-core-connection/src/connection.rs
@@ -23,7 +23,7 @@ use crate::{ConnectionError, ConnectionId, Version};
 
 //#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct IdentifiedConnectionEnd {
     pub connection_id: ConnectionId,
     pub connection_end: ConnectionEnd,
@@ -95,7 +95,7 @@ impl From<IdentifiedConnectionEnd> for RawIdentifiedConnection {
 
 //#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConnectionEnd {
     pub state: State,
     pub client_id: ClientId,
@@ -193,7 +193,7 @@ impl ConnectionEnd {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with_serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Counterparty {
     pub client_id: ClientId,
     pub connection_id: Option<ConnectionId>,
@@ -245,7 +245,7 @@ impl From<Counterparty> for RawCounterparty {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "with_serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum State {
     Uninitialized = 0isize,
     Init = 1isize,

--- a/release.sh
+++ b/release.sh
@@ -62,6 +62,12 @@ publish() {
   echo ""
 }
 
+dry_publish() {
+  echo "Publishing crate $1..."
+  cargo publish --dry-run --manifest-path "$(get_manifest_path "${1}")" ${CARGO_PUBLISH_FLAGS}
+  echo ""
+}
+
 wait_until_available() {
   echo "Waiting for crate ${1} to become available via crates.io..."
   for retry in {1..5}; do
@@ -82,6 +88,38 @@ wait_until_available() {
   echo "Waiting an additional 10 seconds for crate to propagate through CDN..."
   sleep 10
 }
+
+echo "Doing a dry-run"
+for crate in ${CRATES}; do
+  dry_publish "${crate}"
+done
+
+echo "Attempting to publish crate(s): ${CRATES}"
+
+# Since crates.io has rate-limit and we always want to publish 
+# every crate in lockstep, we need to wait 5min every 5 pubs
+COUNTER=1
+
+for crate in ${CRATES}; do
+  VERSION="$(get_local_version "${crate}")"
+  ONLINE_DATE="$(check_version_online "${crate}" "${VERSION}")"
+  echo "${crate} version number: ${VERSION}"
+  if [ -n "${ONLINE_DATE}" ]; then
+    echo "${crate} ${VERSION} has already been published at ${ONLINE_DATE}, skipping"
+    continue
+  fi
+
+  if [ $COUNTER -eq 5 ]; then
+    echo "Reached 5 crates, waiting for 5 minutes..."
+    sleep 300 # Wait for 5 minutes
+    COUNTER=1 # Reset the counter
+  fi
+
+  publish "${crate}"
+  wait_until_available "${crate}" "${VERSION}"
+  ((COUNTER++))
+done
+
 
 echo "Attempting to publish crate(s): ${CRATES}"
 


### PR DESCRIPTION
We should make sure that every crate is ready to be published. Otherwise, we might accidentally publish only a subset of all the crates in the workspace. This PR also adds a timer to avoid triggering the crates.io rate-limiter. Finally, this PR changes the `ibc-types-core-connection` serde feature to `with_serde` to fix trait resolution problems.