### PR TITLE
ci(release): replace `dry-run` with `check_crates.sh`

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -62,12 +62,6 @@ publish() {
   echo ""
 }
 
-dry_publish() {
-  echo "Publishing crate $1..."
-  cargo publish --dry-run --manifest-path "$(get_manifest_path "${1}")" ${CARGO_PUBLISH_FLAGS}
-  echo ""
-}
-
 wait_until_available() {
   echo "Waiting for crate ${1} to become available via crates.io..."
   for retry in {1..5}; do
@@ -89,9 +83,9 @@ wait_until_available() {
   sleep 10
 }
 
-echo "Doing a dry-run"
+echo "Checking that each crate compiles"
 for crate in ${CRATES}; do
-  dry_publish "${crate}"
+    ./check_crates.sh
 done
 
 echo "Attempting to publish crate(s): ${CRATES}"


### PR DESCRIPTION
Dry-runs are generally a good idea, but it's not possible here because our crates reference each other. Replacing the dry-run by running the `check_crates` script.