### PR TITLE
ibc-types: prepare release `v0.6.0`

### DIFF
--- a/crates/ibc-types-core-channel/Cargo.toml
+++ b/crates/ibc-types-core-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-core-channel"
-version      = "0.5.0"
+version      = "0.6.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"

--- a/crates/ibc-types-core-channel/Cargo.toml
+++ b/crates/ibc-types-core-channel/Cargo.toml
@@ -53,12 +53,12 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-ibc-types-core-client = { version = "0.5.0", path = "../ibc-types-core-client", default-features = false }
-ibc-types-core-connection = { version = "0.5.0", path = "../ibc-types-core-connection", default-features = false }
-ibc-types-core-commitment = { version = "0.5.0", path = "../ibc-types-core-commitment", default-features = false }
-ibc-types-domain-type = { version = "0.5.0", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-identifier = { version = "0.5.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-timestamp = { version = "0.5.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-core-client = { version = "0.6.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-core-connection = { version = "0.6.0", path = "../ibc-types-core-connection", default-features = false }
+ibc-types-core-commitment = { version = "0.6.0", path = "../ibc-types-core-commitment", default-features = false }
+ibc-types-domain-type = { version = "0.6.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-identifier = { version = "0.6.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-timestamp = { version = "0.6.0", path = "../ibc-types-timestamp", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
 ibc-proto = { version = "0.33.0", default-features = false }
 ## for borsh encode or decode
@@ -100,6 +100,6 @@ default-features = false
 [dev-dependencies]
 cfg-if = { version = "1.0.0" }
 env_logger = "0.10.0"
-ibc-types-core-client = { version = "0.5.0", path = "../ibc-types-core-client", features = ["mocks"] }
+ibc-types-core-client = { version = "0.6.0", path = "../ibc-types-core-client", features = ["mocks"] }
 test-log = { version = "0.2.10", features = ["trace"] }
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}

--- a/crates/ibc-types-core-channel/Cargo.toml
+++ b/crates/ibc-types-core-channel/Cargo.toml
@@ -42,7 +42,7 @@ parity-scale-codec = ["dep:parity-scale-codec", "dep:scale-info"]
 borsh = ["dep:borsh"]
 
 # This feature is required for token transfer (ICS-20)
-serde = ["dep:serde", "dep:serde_derive", "serde_json"]
+with_serde = ["serde", "serde_derive", "serde_json"]
 
 # This feature guards the unfinished implementation of the `UpgradeClient` handler.
 upgrade_client = []

--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-core-client"
-version      = "0.5.0"
+version      = "0.6.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"

--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -38,7 +38,7 @@ parity-scale-codec = ["dep:parity-scale-codec", "dep:scale-info"]
 borsh = ["dep:borsh"]
 
 # This feature is required for token transfer (ICS-20)
-serde = ["dep:serde", "dep:serde_derive", "serde_json"]
+with_serde = ["serde", "serde_derive", "serde_json"]
 
 # This feature guards the unfinished implementation of the `UpgradeClient` handler.
 upgrade_client = []

--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -55,9 +55,9 @@ cfg-if = { version = "1.0.0", optional = true }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 displaydoc = { version = "0.2", default-features = false }
 ibc-proto = { version = "0.33.0", default-features = false }
-ibc-types-domain-type = { version = "0.5.0", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-identifier = { version = "0.5.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-timestamp = { version = "0.5.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-domain-type = { version = "0.6.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-identifier = { version = "0.6.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-timestamp = { version = "0.6.0", path = "../ibc-types-timestamp", default-features = false }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }

--- a/crates/ibc-types-core-commitment/Cargo.toml
+++ b/crates/ibc-types-core-commitment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-core-commitment"
-version      = "0.5.0"
+version      = "0.6.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"

--- a/crates/ibc-types-core-commitment/Cargo.toml
+++ b/crates/ibc-types-core-commitment/Cargo.toml
@@ -54,9 +54,9 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-ibc-types-timestamp = { version = "0.5.0", path = "../ibc-types-timestamp", default-features = false }
-ibc-types-identifier = { version = "0.5.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-domain-type = { version = "0.5.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-timestamp = { version = "0.6.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-identifier = { version = "0.6.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-domain-type = { version = "0.6.0", path = "../ibc-types-domain-type", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
 ibc-proto = { version = "0.33.0", default-features = false }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }

--- a/crates/ibc-types-core-commitment/Cargo.toml
+++ b/crates/ibc-types-core-commitment/Cargo.toml
@@ -43,7 +43,7 @@ parity-scale-codec = ["dep:parity-scale-codec", "dep:scale-info"]
 borsh = ["dep:borsh"]
 
 # This feature is required for token transfer (ICS-20)
-serde = ["dep:serde", "dep:serde_derive", "serde_json", "erased-serde"]
+with_serde = ["serde", "serde_derive", "serde_json", "erased-serde"]
 
 # This feature guards the unfinished implementation of the `UpgradeClient` handler.
 upgrade_client = []

--- a/crates/ibc-types-core-connection/Cargo.toml
+++ b/crates/ibc-types-core-connection/Cargo.toml
@@ -51,11 +51,11 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-ibc-types-timestamp = { version = "0.5.0", path = "../ibc-types-timestamp", default-features = false }
-ibc-types-core-commitment = { version = "0.5.0", path = "../ibc-types-core-commitment", default-features = false }
-ibc-types-identifier = { version = "0.5.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-domain-type = { version = "0.5.0", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-core-client = { version = "0.5.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-timestamp = { version = "0.6.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-core-commitment = { version = "0.6.0", path = "../ibc-types-core-commitment", default-features = false }
+ibc-types-identifier = { version = "0.6.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-domain-type = { version = "0.6.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-core-client = { version = "0.6.0", path = "../ibc-types-core-client", default-features = false }
 borsh = {version = "0.10.0", default-features = false, optional = true }
 bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
@@ -95,5 +95,5 @@ env_logger = "0.10.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
 test-log = { version = "0.2.10", features = ["trace"] }
 cfg-if = { version = "1.0.0" }
-ibc-types-core-client = { version = "0.5.0", path = "../ibc-types-core-client", features = ["mocks"] }
+ibc-types-core-client = { version = "0.6.0", path = "../ibc-types-core-client", features = ["mocks"] }
 tracing = { version = "0.1.36", default-features = false }

--- a/crates/ibc-types-core-connection/Cargo.toml
+++ b/crates/ibc-types-core-connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-core-connection"
-version      = "0.5.0"
+version      = "0.6.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"

--- a/crates/ibc-types-domain-type/Cargo.toml
+++ b/crates/ibc-types-domain-type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibc-types-domain-type"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license      = "Apache-2.0"
 publish = true

--- a/crates/ibc-types-identifier/Cargo.toml
+++ b/crates/ibc-types-identifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-identifier"
-version      = "0.5.0"
+version      = "0.6.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"

--- a/crates/ibc-types-lightclients-tendermint/Cargo.toml
+++ b/crates/ibc-types-lightclients-tendermint/Cargo.toml
@@ -45,7 +45,7 @@ parity-scale-codec = ["dep:parity-scale-codec", "dep:scale-info"]
 borsh = ["dep:borsh"]
 
 # This feature is required for token transfer (ICS-20)
-serde = ["dep:serde", "dep:serde_derive", "serde_json", "erased-serde"]
+with_serde = ["serde", "serde_derive", "serde_json", "erased-serde"]
 
 # This feature guards the unfinished implementation of the `UpgradeClient` handler.
 upgrade_client = []

--- a/crates/ibc-types-lightclients-tendermint/Cargo.toml
+++ b/crates/ibc-types-lightclients-tendermint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-lightclients-tendermint"
-version      = "0.5.0"
+version      = "0.6.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"

--- a/crates/ibc-types-lightclients-tendermint/Cargo.toml
+++ b/crates/ibc-types-lightclients-tendermint/Cargo.toml
@@ -56,12 +56,12 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-ibc-types-timestamp = { version = "0.5.0", path = "../ibc-types-timestamp", default-features = false }
-ibc-types-identifier = { version = "0.5.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-domain-type = { version = "0.5.0", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-core-client = { version = "0.5.0", path = "../ibc-types-core-client", default-features = false }
-ibc-types-core-connection = { version = "0.5.0", path = "../ibc-types-core-connection", default-features = false }
-ibc-types-core-commitment = { version = "0.5.0", path = "../ibc-types-core-commitment", default-features = false }
+ibc-types-timestamp = { version = "0.6.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-identifier = { version = "0.6.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-domain-type = { version = "0.6.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-core-client = { version = "0.6.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-core-connection = { version = "0.6.0", path = "../ibc-types-core-connection", default-features = false }
+ibc-types-core-commitment = { version = "0.6.0", path = "../ibc-types-core-commitment", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
 ibc-proto = { version = "0.33.0", default-features = false }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
@@ -119,4 +119,4 @@ tendermint-testgen = { version = "0.33.0" } # Needed for generating (synthetic) 
 parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }
 
-ibc-types-core-client = { version = "0.5.0", path = "../ibc-types-core-client", features = ["mocks"] }
+ibc-types-core-client = { version = "0.6.0", path = "../ibc-types-core-client", features = ["mocks"] }

--- a/crates/ibc-types-path/Cargo.toml
+++ b/crates/ibc-types-path/Cargo.toml
@@ -34,6 +34,8 @@ std = [
     "ibc-types-core-channel/std",
 ]
 
+with_serde = ["serde", "serde_derive", "serde_json"]
+
 # This feature guards the unfinished implementation of the `UpgradeClient` handler.
 upgrade_client = []
 

--- a/crates/ibc-types-path/Cargo.toml
+++ b/crates/ibc-types-path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-path"
-version      = "0.5.0"
+version      = "0.6.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"

--- a/crates/ibc-types-path/Cargo.toml
+++ b/crates/ibc-types-path/Cargo.toml
@@ -46,9 +46,9 @@ mocks-no-std = ["cfg-if"]
 
 [dependencies]
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
-ibc-types-core-client = { version = "0.5.0", path = "../ibc-types-core-client", default-features = false }
-ibc-types-core-connection = { version = "0.5.0", path = "../ibc-types-core-connection", default-features = false }
-ibc-types-core-channel = { version = "0.5.0", path = "../ibc-types-core-channel", default-features = false }
+ibc-types-core-client = { version = "0.6.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-core-connection = { version = "0.6.0", path = "../ibc-types-core-connection", default-features = false }
+ibc-types-core-channel = { version = "0.6.0", path = "../ibc-types-core-channel", default-features = false }
 borsh = {version = "0.10.0", default-features = false, optional = true }
 bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }

--- a/crates/ibc-types-timestamp/Cargo.toml
+++ b/crates/ibc-types-timestamp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-timestamp"
-version      = "0.5.0"
+version      = "0.6.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"

--- a/crates/ibc-types-timestamp/Cargo.toml
+++ b/crates/ibc-types-timestamp/Cargo.toml
@@ -30,6 +30,7 @@ std = [
     "tendermint/clock",
     "tendermint/std",
 ]
+with_serde = ["serde", "serde_derive", "serde_json"]
 
 # This feature guards the unfinished implementation of the `UpgradeClient` handler.
 upgrade_client = []

--- a/crates/ibc-types-transfer/Cargo.toml
+++ b/crates/ibc-types-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-transfer"
-version      = "0.5.0"
+version      = "0.6.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"

--- a/crates/ibc-types/Cargo.toml
+++ b/crates/ibc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types"
-version      = "0.5.0"
+version      = "0.6.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"

--- a/crates/ibc-types/Cargo.toml
+++ b/crates/ibc-types/Cargo.toml
@@ -56,13 +56,13 @@ mocks = [
 ]
 
 [dependencies]
-ibc-types-timestamp = { version = "0.5.0", path = "../ibc-types-timestamp", default-features = false }
-ibc-types-identifier = { version = "0.5.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-domain-type = { version = "0.5.0", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-core-client = { version = "0.5.0", path = "../ibc-types-core-client", default-features = false }
-ibc-types-core-connection = { version = "0.5.0", path = "../ibc-types-core-connection", default-features = false }
-ibc-types-core-channel = { version = "0.5.0", path = "../ibc-types-core-channel", default-features = false }
-ibc-types-core-commitment = { version = "0.5.0", path = "../ibc-types-core-commitment", default-features = false }
-ibc-types-lightclients-tendermint = { version = "0.5.0", path = "../ibc-types-lightclients-tendermint", default-features = false }
-ibc-types-path = { version = "0.5.0", path = "../ibc-types-path", default-features = false }
-ibc-types-transfer = { version = "0.5.0", path = "../ibc-types-transfer", default-features = false }
+ibc-types-timestamp = { version = "0.6.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-identifier = { version = "0.6.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-domain-type = { version = "0.6.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-core-client = { version = "0.6.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-core-connection = { version = "0.6.0", path = "../ibc-types-core-connection", default-features = false }
+ibc-types-core-channel = { version = "0.6.0", path = "../ibc-types-core-channel", default-features = false }
+ibc-types-core-commitment = { version = "0.6.0", path = "../ibc-types-core-commitment", default-features = false }
+ibc-types-lightclients-tendermint = { version = "0.6.0", path = "../ibc-types-lightclients-tendermint", default-features = false }
+ibc-types-path = { version = "0.6.0", path = "../ibc-types-path", default-features = false }
+ibc-types-transfer = { version = "0.6.0", path = "../ibc-types-transfer", default-features = false }

--- a/crates/ibc-types/Cargo.toml
+++ b/crates/ibc-types/Cargo.toml
@@ -30,6 +30,18 @@ std = [
     "ibc-types-transfer/std",
 ]
 
+with_serde = [
+    "ibc-types-timestamp/with_serde",
+    "ibc-types-identifier/with_serde",
+    "ibc-types-core-client/with_serde",
+    "ibc-types-core-connection/with_serde",
+    "ibc-types-core-channel/with_serde",
+    "ibc-types-core-commitment/with_serde",
+    "ibc-types-lightclients-tendermint/with_serde",
+    "ibc-types-path/with_serde",
+    "ibc-types-transfer/with_serde",
+    ]
+
 # This feature grants access to development-time mocking libraries, such as `MockContext` or `MockHeader`.
 # Depends on the `testgen` suite for generating Tendermint light blocks.
 mocks = [


### PR DESCRIPTION
This PR adds a `with_serde` feature to the root level crate that will activate `serde_derive`s in the subcrates. The reason is that the collision between `feature:serde` (which imports `serde`, `serde_derive` etc.) and `dep:serde` (imports the optional dependency `serde`) is causing problems with cargo when there are multiple levels of imports. To make matters more simple, we are creating a `with_serde` feature that activates everything serde related (`serde_json`, `serde_derive`, `erased-serde` etc.).