### PR TITLE
docs: fix dead links

### DIFF
--- a/docs/architecture/adr-006-upgrade-client-implementation.md
+++ b/docs/architecture/adr-006-upgrade-client-implementation.md
@@ -18,7 +18,7 @@ to justify the chain-wide logic behind upgrading light clients, list requisites
 for validation and execution steps, determine the boundary between basic and
 upgrade-specific validations by an IBC handler, and explain Tendermint's upgrade
 client implementation within the
-[ics07_tendermint](../../crates/ibc-types/src/clients/ics07_tendermint).
+[ics07_tendermint](../../crates/ibc-types-core-client/src/msgs/upgrade_client.rs).
 
 ## Decision
 
@@ -39,9 +39,9 @@ implementation of this rationale in `IBC-rs` is explained.
 * There **MUST** be a proof verification process to check upgraded client and
   consensus states against the host chain's state.
 * Chain upgrades **MUST NOT** result in changing
-  [ClientState](../../crates/ibc-types/src/core/ics02_client/client_state.rs#ClientState)
+  [ClientState](../../crates/ibc-types-lightclients-tendermint/src/client_state.rs)
   or
-  [ConsensusState](../../crates/ibc-types/src/core/ics02_client/consensus_state.rs#ConsensusState)
+  [ConsensusState](../../crates/ibc-types-lightclients-tendermint/src/client_state.rs)
   implementations
 * It is **UP TO** the chain's architecture how updated client and consensus
   states are committed, either through decentralized approaches, like governance
@@ -102,9 +102,9 @@ supported by `IBC-rs`:
    recommended that chains reduce the unbonding period.
 7. (P) Changing the Tendermint LightClient algorithm: Changes to the light
    client algorithm that do not change the
-   [ClientState](../../crates/ibc-types/src/clients/ics07_tendermint/client_state.rs#ClientState)
+   [ClientState](../../crates/ibc-types-core-client/src/mock/client_state.rs)
    or
-   [ConsensusState](../../crates/ibc-types/src/clients/ics07_tendermint/consensus_state.rs#ConsensusState)
+   [ConsensusState](../../crates/ibc-types-lightclients-tendermint/src/consensus_state.rs)
    struct abstraction may be supported, provided that the counterparty is also
    upgraded to support the new light client algorithm. Changes that require
    updating the `ClientState` and `ConsensusState` structs themselves are
@@ -204,7 +204,7 @@ validations (SV) and lastly execution (E) steps as follows:
 
 Whenever the IBC handler receives an `MsgUpgradeClient`, it dispatches the
 decoded message to the router and triggers the
-[process](../../crates/ibc-types/src/core/ics02_client/handler/upgrade_client.rs#process)
+[process](../../crates/ibc-types-core-client/src/msgs/upgrade_client.rs)
 function of `upgrade_client` handler, which would go through the steps outlined
 in 3rd section of [Upgrade Process Step-by-Step](#upgrade-process-step-by-step).
 Just note that the `process` function will be rendered into `validate` and
@@ -419,7 +419,7 @@ Proposed
 * [cosmos/ibc-go/Issue 445: IBC upgrade plan
   summary](https://github.com/cosmos/ibc/issues/445)
 * [cosmos/cosmos-sdk/PR 7367: Upgrade
-  Client](https://github.com/cosmos/cosmos-sdk/åpull/7367)
+  Client](https://github.com/cosmos/cosmos-sdk/pull/7367)
 * [cosmos/ibc-go/Issue 2501: Create importable workflow for chains to run
   upgrade tests](https://github.com/cosmos/ibc-go/issues/2501)
 * [Hermes relayer documentation: Client


### PR DESCRIPTION
The `markdown-link-check` CI job was failing. Updated the in-repo URLs in the `docs/` folder to get it passing again. These changes are superficial: we may want to ditch those vestigial docs altogether, in favor of detailed rustdocs.