### PR TITLE
ibc-types: switch to latest tendermint bindings and ics23 spec

### DIFF
--- a/ci/no-std-check/Cargo.toml
+++ b/ci/no-std-check/Cargo.toml
@@ -9,7 +9,7 @@ ibc-types = { path = "../../crates/ibc-types", default-features = false, feature
   "serde",
   "mocks-no-std",
 ] }
-ibc-proto = { version = "0.33.0", default-features = false }
+ibc-proto = { version = "0.37.0", default-features = false }
 tendermint = { version = "0.33.0", default-features = false }
 tendermint-proto = { version = "0.33.0", default-features = false }
 tendermint-light-client-verifier = { version = "0.33.0", default-features = false, features = ["rust-crypto"] }

--- a/ci/no-std-check/Cargo.toml
+++ b/ci/no-std-check/Cargo.toml
@@ -10,9 +10,9 @@ ibc-types = { path = "../../crates/ibc-types", default-features = false, feature
   "mocks-no-std",
 ] }
 ibc-proto = { version = "0.37.0", default-features = false }
-tendermint = { version = "0.33.0", default-features = false }
-tendermint-proto = { version = "0.33.0", default-features = false }
-tendermint-light-client-verifier = { version = "0.33.0", default-features = false, features = ["rust-crypto"] }
+tendermint = { version = "0.34.0", default-features = false }
+tendermint-proto = { version = "0.34.0", default-features = false }
+tendermint-light-client-verifier = { version = "0.34.0", default-features = false, features = ["rust-crypto"] }
 
 sp-core = { version = "17.0.0", default-features = false, optional = true }
 sp-io = { version = "18.0.0", default-features = false, optional = true }

--- a/crates/ibc-types-core-channel/Cargo.toml
+++ b/crates/ibc-types-core-channel/Cargo.toml
@@ -60,7 +60,7 @@ ibc-types-domain-type = { version = "0.6.4", path = "../ibc-types-domain-type", 
 ibc-types-identifier = { version = "0.6.4", path = "../ibc-types-identifier", default-features = false }
 ibc-types-timestamp = { version = "0.6.4", path = "../ibc-types-timestamp", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.33.0", default-features = false }
+ibc-proto = { version = "0.37.0", default-features = false }
 ## for borsh encode or decode
 borsh = {version = "0.10.0", default-features = false, optional = true }
 bytes = { version = "1.2.1", default-features = false }

--- a/crates/ibc-types-core-channel/Cargo.toml
+++ b/crates/ibc-types-core-channel/Cargo.toml
@@ -87,15 +87,15 @@ scale-info = { version = "2.1.2", default-features = false, features = ["derive"
 anyhow = { version = "1", default-features = false }
 
 [dependencies.tendermint]
-version = "0.33.0"
+version = "0.34.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.33.0"
+version = "0.34.0"
 default-features = false
 
 [dependencies.tendermint-testgen]
-version = "0.33.0"
+version = "0.34.0"
 optional = true
 default-features = false
 

--- a/crates/ibc-types-core-channel/Cargo.toml
+++ b/crates/ibc-types-core-channel/Cargo.toml
@@ -67,7 +67,7 @@ bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 displaydoc = { version = "0.2", default-features = false }
-ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
+ics23 = { version = "0.11.0", default-features = false, features = ["host-functions"] }
 num-traits = { version = "0.2.15", default-features = false }
 ## for codec encode or decode
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }

--- a/crates/ibc-types-core-channel/Cargo.toml
+++ b/crates/ibc-types-core-channel/Cargo.toml
@@ -72,7 +72,7 @@ num-traits = { version = "0.2.15", default-features = false }
 ## for codec encode or decode
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
 parking_lot = { version = "0.12.1", default-features = false, optional = true }
-prost = { version = "0.11", default-features = false }
+prost = { version = "0.12", default-features = false }
 safe-regex = { version = "0.2.5", default-features = false }
 # proc-macro2 to unbreak docs.rs build, see GH#56
 proc-macro2 = { version = "0.1", default-features = false }

--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -72,11 +72,11 @@ time = { version = ">=0.3.0, <0.3.20", default-features = false }
 anyhow = { version = "1", default-features = false }
 
 [dependencies.tendermint]
-version = "0.33.0"
+version = "0.34.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.33.0"
+version = "0.34.0"
 default-features = false
 
 [dev-dependencies]

--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -58,7 +58,7 @@ ibc-proto = { version = "0.37.0", default-features = false }
 ibc-types-domain-type = { version = "0.6.4", path = "../ibc-types-domain-type", default-features = false }
 ibc-types-identifier = { version = "0.6.4", path = "../ibc-types-identifier", default-features = false }
 ibc-types-timestamp = { version = "0.6.4", path = "../ibc-types-timestamp", default-features = false }
-ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
+ics23 = { version = "0.11.0", default-features = false, features = ["host-functions"] }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
 prost = { version = "0.12", default-features = false }

--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -54,7 +54,7 @@ bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 displaydoc = { version = "0.2", default-features = false }
-ibc-proto = { version = "0.33.0", default-features = false }
+ibc-proto = { version = "0.37.0", default-features = false }
 ibc-types-domain-type = { version = "0.6.4", path = "../ibc-types-domain-type", default-features = false }
 ibc-types-identifier = { version = "0.6.4", path = "../ibc-types-identifier", default-features = false }
 ibc-types-timestamp = { version = "0.6.4", path = "../ibc-types-timestamp", default-features = false }

--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -61,7 +61,7 @@ ibc-types-timestamp = { version = "0.6.4", path = "../ibc-types-timestamp", defa
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
-prost = { version = "0.11", default-features = false }
+prost = { version = "0.12", default-features = false }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }

--- a/crates/ibc-types-core-client/src/error.rs
+++ b/crates/ibc-types-core-client/src/error.rs
@@ -60,6 +60,8 @@ pub enum Error {
     InvalidRawHeader(TendermintProtoError),
     /// missing raw header
     MissingRawHeader,
+    /// missing raw client message
+    MissingRawClientMessage,
     /// invalid raw misbehaviour error: `{0}`
     InvalidRawMisbehaviour(IdentifierError),
     /// missing raw misbehaviour

--- a/crates/ibc-types-core-client/src/msgs/misbehaviour.rs
+++ b/crates/ibc-types-core-client/src/msgs/misbehaviour.rs
@@ -30,6 +30,7 @@ impl DomainType for MsgSubmitMisbehaviour {
 impl TryFrom<RawMsgSubmitMisbehaviour> for MsgSubmitMisbehaviour {
     type Error = Error;
 
+    #[allow(deprecated)]
     fn try_from(raw: RawMsgSubmitMisbehaviour) -> Result<Self, Self::Error> {
         let raw_misbehaviour = raw.misbehaviour.ok_or(Error::MissingRawMisbehaviour)?;
 
@@ -45,6 +46,7 @@ impl TryFrom<RawMsgSubmitMisbehaviour> for MsgSubmitMisbehaviour {
 }
 
 impl From<MsgSubmitMisbehaviour> for RawMsgSubmitMisbehaviour {
+    #[allow(deprecated)]
     fn from(ics_msg: MsgSubmitMisbehaviour) -> Self {
         RawMsgSubmitMisbehaviour {
             client_id: ics_msg.client_id.to_string(),

--- a/crates/ibc-types-core-client/src/msgs/update_client.rs
+++ b/crates/ibc-types-core-client/src/msgs/update_client.rs
@@ -13,7 +13,7 @@ use crate::{error::Error, ClientId};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MsgUpdateClient {
     pub client_id: ClientId,
-    pub header: Any,
+    pub client_message: Any,
     pub signer: String,
 }
 
@@ -34,7 +34,7 @@ impl TryFrom<RawMsgUpdateClient> for MsgUpdateClient {
                 .client_id
                 .parse()
                 .map_err(Error::InvalidMsgUpdateClientId)?,
-            header: raw.header.ok_or(Error::MissingRawHeader)?,
+            client_message: raw.client_message.ok_or(Error::MissingRawClientMessage)?,
             signer: raw.signer,
         })
     }
@@ -44,7 +44,7 @@ impl From<MsgUpdateClient> for RawMsgUpdateClient {
     fn from(ics_msg: MsgUpdateClient) -> Self {
         RawMsgUpdateClient {
             client_id: ics_msg.client_id.to_string(),
-            header: Some(ics_msg.header),
+            client_message: Some(ics_msg.client_message),
             signer: ics_msg.signer,
         }
     }

--- a/crates/ibc-types-core-commitment/Cargo.toml
+++ b/crates/ibc-types-core-commitment/Cargo.toml
@@ -67,7 +67,7 @@ serde = { version = "1.0", default-features = false, optional = true }
 serde_json = { version = "1", default-features = false, optional = true }
 erased-serde = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
 tracing = { version = "0.1.36", default-features = false }
-prost = { version = "0.11", default-features = false }
+prost = { version = "0.12", default-features = false }
 bytes = { version = "1.2.1", default-features = false }
 safe-regex = { version = "0.2.5", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false }

--- a/crates/ibc-types-core-commitment/Cargo.toml
+++ b/crates/ibc-types-core-commitment/Cargo.toml
@@ -89,20 +89,20 @@ anyhow = "1"
 hex = { version = "0.4.3", default-features = false }
 
 [dependencies.tendermint]
-version = "0.33.0"
+version = "0.34.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.33.0"
+version = "0.34.0"
 default-features = false
 
 [dependencies.tendermint-light-client-verifier]
-version = "0.33.0"
+version = "0.34.0"
 default-features = false
 features = ["rust-crypto"]
 
 [dependencies.tendermint-testgen]
-version = "0.33.0"
+version = "0.34.0"
 optional = true
 default-features = false
 
@@ -111,8 +111,8 @@ env_logger = "0.10.0"
 rstest = "0.16.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
 test-log = { version = "0.2.10", features = ["trace"] }
-tendermint-rpc = { version = "0.33.0", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { version = "0.33.0" } # Needed for generating (synthetic) light blocks.
+tendermint-rpc = { version = "0.34.0", features = ["http-client", "websocket-client"] }
+tendermint-testgen = { version = "0.34.0" } # Needed for generating (synthetic) light blocks.
 parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }
 

--- a/crates/ibc-types-core-commitment/Cargo.toml
+++ b/crates/ibc-types-core-commitment/Cargo.toml
@@ -60,7 +60,7 @@ ibc-types-identifier = { version = "0.6.4", path = "../ibc-types-identifier", de
 ibc-types-domain-type = { version = "0.6.4", path = "../ibc-types-domain-type", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
 ibc-proto = { version = "0.37.0", default-features = false }
-ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
+ics23 = { version = "0.11.0", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }

--- a/crates/ibc-types-core-commitment/Cargo.toml
+++ b/crates/ibc-types-core-commitment/Cargo.toml
@@ -59,7 +59,7 @@ ibc-types-timestamp = { version = "0.6.4", path = "../ibc-types-timestamp", defa
 ibc-types-identifier = { version = "0.6.4", path = "../ibc-types-identifier", default-features = false }
 ibc-types-domain-type = { version = "0.6.4", path = "../ibc-types-domain-type", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.33.0", default-features = false }
+ibc-proto = { version = "0.37.0", default-features = false }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }

--- a/crates/ibc-types-core-connection/Cargo.toml
+++ b/crates/ibc-types-core-connection/Cargo.toml
@@ -62,7 +62,7 @@ cfg-if = { version = "1.0.0", optional = true }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 displaydoc = { version = "0.2", default-features = false }
 ibc-proto = { version = "0.37.0", default-features = false }
-ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
+ics23 = { version = "0.11.0", default-features = false, features = ["host-functions"] }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
 parking_lot = { version = "0.12.1", default-features = false, optional = true }

--- a/crates/ibc-types-core-connection/Cargo.toml
+++ b/crates/ibc-types-core-connection/Cargo.toml
@@ -66,7 +66,7 @@ ics23 = { version = "0.10.1", default-features = false, features = ["host-functi
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
 parking_lot = { version = "0.12.1", default-features = false, optional = true }
-prost = { version = "0.11", default-features = false }
+prost = { version = "0.12", default-features = false }
 safe-regex = { version = "0.2.5", default-features = false }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
 serde = { version = "1.0", default-features = false, optional = true }

--- a/crates/ibc-types-core-connection/Cargo.toml
+++ b/crates/ibc-types-core-connection/Cargo.toml
@@ -61,7 +61,7 @@ bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 displaydoc = { version = "0.2", default-features = false }
-ibc-proto = { version = "0.33.0", default-features = false }
+ibc-proto = { version = "0.37.0", default-features = false }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }

--- a/crates/ibc-types-core-connection/Cargo.toml
+++ b/crates/ibc-types-core-connection/Cargo.toml
@@ -78,15 +78,15 @@ time = { version = ">=0.3.0, <0.3.20", default-features = false }
 anyhow = { version = "1", default-features = false }
 
 [dependencies.tendermint]
-version = "0.33.0"
+version = "0.34.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.33.0"
+version = "0.34.0"
 default-features = false
 
 [dependencies.tendermint-testgen]
-version = "0.33.0"
+version = "0.34.0"
 optional = true
 default-features = false
 

--- a/crates/ibc-types-core-connection/src/msgs/conn_open_ack.rs
+++ b/crates/ibc-types-core-connection/src/msgs/conn_open_ack.rs
@@ -30,7 +30,7 @@ pub struct MsgConnectionOpenAck {
     pub proofs_height_on_b: Height,
     /// height of latest header of chain A that updated the client on chain B
     pub consensus_height_of_a_on_b: Height,
-    ///
+    /// optional proof of the consensus state of the host chain, see: https://github.com/cosmos/ibc/pull/839
     host_consensus_state_proof: Option<MerkleProof>,
     pub version: Version,
     pub signer: String,

--- a/crates/ibc-types-core-connection/src/msgs/conn_open_try.rs
+++ b/crates/ibc-types-core-connection/src/msgs/conn_open_try.rs
@@ -41,6 +41,7 @@ pub struct MsgConnectionOpenTry {
     pub consensus_height_of_b_on_a: Height,
     pub delay_period: Duration,
     pub signer: String,
+    pub proof_consensus_state_of_b: Option<MerkleProof>,
 
     #[deprecated(since = "0.22.0")]
     /// Only kept here for proper conversion to/from the raw type
@@ -102,6 +103,14 @@ impl TryFrom<RawMsgConnectionOpenTry> for MsgConnectionOpenTry {
                 .ok_or(ConnectionError::MissingConsensusHeight)?,
             delay_period: Duration::from_nanos(msg.delay_period),
             signer: msg.signer,
+            proof_consensus_state_of_b: if msg.host_consensus_state_proof.is_empty() {
+                None
+            } else {
+                Some(
+                    MerkleProof::decode(msg.host_consensus_state_proof.as_ref())
+                        .map_err(|_| ConnectionError::InvalidProof)?,
+                )
+            },
         })
     }
 }
@@ -122,6 +131,10 @@ impl From<MsgConnectionOpenTry> for RawMsgConnectionOpenTry {
             proof_consensus: msg.proof_consensus_state_of_b_on_a.encode_to_vec(),
             consensus_height: Some(msg.consensus_height_of_b_on_a.into()),
             signer: msg.signer,
+            host_consensus_state_proof: match msg.proof_consensus_state_of_b {
+                Some(proof) => proof.encode_to_vec(),
+                None => vec![],
+            },
         }
     }
 }
@@ -195,6 +208,7 @@ pub mod test_util {
             }),
             proof_client: get_dummy_proof(),
             signer: get_dummy_bech32_account(),
+            host_consensus_state_proof: vec![],
         }
     }
 }

--- a/crates/ibc-types-domain-type/Cargo.toml
+++ b/crates/ibc-types-domain-type/Cargo.toml
@@ -20,5 +20,5 @@ all-features = true
 
 [dependencies]
 anyhow = { version = "1", default-features = false }
-prost = { version = "0.11", default-features = false }
+prost = { version = "0.12", default-features = false }
 bytes = { version = "1.2.1", default-features = false }

--- a/crates/ibc-types-lightclients-tendermint/Cargo.toml
+++ b/crates/ibc-types-lightclients-tendermint/Cargo.toml
@@ -63,7 +63,7 @@ ibc-types-core-client = { version = "0.6.4", path = "../ibc-types-core-client", 
 ibc-types-core-connection = { version = "0.6.4", path = "../ibc-types-core-connection", default-features = false }
 ibc-types-core-commitment = { version = "0.6.4", path = "../ibc-types-core-commitment", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.33.0", default-features = false }
+ibc-proto = { version = "0.37.0", default-features = false }
 ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }
@@ -92,20 +92,20 @@ cfg-if = { version = "1.0.0", optional = true }
 anyhow = { version = "1", default-features = false }
 
 [dependencies.tendermint]
-version = "0.33.0"
+version = "0.34.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.33.0"
+version = "0.34.0"
 default-features = false
 
 [dependencies.tendermint-light-client-verifier]
-version = "0.33.0"
+version = "0.34.0"
 default-features = false
 features = ["rust-crypto"]
 
 [dependencies.tendermint-testgen]
-version = "0.33.0"
+version = "0.34.0"
 optional = true
 default-features = false
 
@@ -114,8 +114,8 @@ env_logger = "0.10.0"
 rstest = "0.16.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
 test-log = { version = "0.2.10", features = ["trace"] }
-tendermint-rpc = { version = "0.33.0", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { version = "0.33.0" } # Needed for generating (synthetic) light blocks.
+tendermint-rpc = { version = "0.34.0", features = ["http-client", "websocket-client"] }
+tendermint-testgen = { version = "0.34.0" } # Needed for generating (synthetic) light blocks.
 parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }
 

--- a/crates/ibc-types-lightclients-tendermint/Cargo.toml
+++ b/crates/ibc-types-lightclients-tendermint/Cargo.toml
@@ -71,7 +71,7 @@ serde = { version = "1.0", default-features = false, optional = true }
 serde_json = { version = "1", default-features = false, optional = true }
 erased-serde = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
 tracing = { version = "0.1.36", default-features = false }
-prost = { version = "0.11", default-features = false }
+prost = { version = "0.12", default-features = false }
 bytes = { version = "1.2.1", default-features = false }
 safe-regex = { version = "0.2.5", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false }

--- a/crates/ibc-types-lightclients-tendermint/Cargo.toml
+++ b/crates/ibc-types-lightclients-tendermint/Cargo.toml
@@ -64,7 +64,7 @@ ibc-types-core-connection = { version = "0.6.4", path = "../ibc-types-core-conne
 ibc-types-core-commitment = { version = "0.6.4", path = "../ibc-types-core-commitment", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
 ibc-proto = { version = "0.37.0", default-features = false }
-ics23 = { version = "0.10.1", default-features = false, features = ["host-functions"] }
+ics23 = { version = "0.11.0", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }

--- a/crates/ibc-types-lightclients-tendermint/src/misbehaviour.rs
+++ b/crates/ibc-types-lightclients-tendermint/src/misbehaviour.rs
@@ -87,6 +87,7 @@ impl Protobuf<RawMisbehaviour> for Misbehaviour {}
 impl TryFrom<RawMisbehaviour> for Misbehaviour {
     type Error = Error;
 
+    #[allow(deprecated)]
     fn try_from(raw: RawMisbehaviour) -> Result<Self, Self::Error> {
         let client_id = raw
             .client_id
@@ -112,6 +113,7 @@ impl TryFrom<RawMisbehaviour> for Misbehaviour {
 }
 
 impl From<Misbehaviour> for RawMisbehaviour {
+    #[allow(deprecated)]
     fn from(value: Misbehaviour) -> Self {
         RawMisbehaviour {
             client_id: value.client_id.to_string(),

--- a/crates/ibc-types-path/Cargo.toml
+++ b/crates/ibc-types-path/Cargo.toml
@@ -63,9 +63,9 @@ serde_derive = { version = "1.0.104", default-features = false, optional = true 
 serde_json = { version = "1", default-features = false, optional = true }
 subtle-encoding = { version = "0.5", default-features = false }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
-tendermint = { version = "0.33.0", default-features = false }
-tendermint-proto = { version = "0.33.0", default-features = false }
-tendermint-testgen = { version = "0.33.0", default-features = false, optional = true }
+tendermint = { version = "0.34.0", default-features = false }
+tendermint-proto = { version = "0.34.0", default-features = false }
+tendermint-testgen = { version = "0.34.0", default-features = false, optional = true }
 
 [dev-dependencies]
 cfg-if = { version = "1.0.0" }

--- a/crates/ibc-types-path/Cargo.toml
+++ b/crates/ibc-types-path/Cargo.toml
@@ -56,7 +56,7 @@ displaydoc = { version = "0.2", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
 parking_lot = { version = "0.12.1", default-features = false, optional = true }
-prost = { version = "0.11", default-features = false }
+prost = { version = "0.12", default-features = false }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }

--- a/crates/ibc-types-timestamp/Cargo.toml
+++ b/crates/ibc-types-timestamp/Cargo.toml
@@ -48,7 +48,7 @@ displaydoc = { version = "0.2", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
 parking_lot = { version = "0.12.1", default-features = false, optional = true }
-prost = { version = "0.11", default-features = false }
+prost = { version = "0.12", default-features = false }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }

--- a/crates/ibc-types-timestamp/Cargo.toml
+++ b/crates/ibc-types-timestamp/Cargo.toml
@@ -55,9 +55,9 @@ serde_derive = { version = "1.0.104", default-features = false, optional = true 
 serde_json = { version = "1", default-features = false, optional = true }
 subtle-encoding = { version = "0.5", default-features = false }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
-tendermint = { version = "0.33.0", default-features = false }
-tendermint-proto = { version = "0.33.0", default-features = false }
-tendermint-testgen = { version = "0.33.0", default-features = false, optional = true }
+tendermint = { version = "0.34.0", default-features = false }
+tendermint-proto = { version = "0.34.0", default-features = false }
+tendermint-testgen = { version = "0.34.0", default-features = false, optional = true }
 
 [dev-dependencies]
 cfg-if = { version = "1.0.0" }


### PR DESCRIPTION
This PR integrates the latest release of `tendermint-rs@0.34`, `ibc-proto-rs@0.37`, `ics23@0.11`, and switch prost to `0.12`. With this release, comes support for a new optional ics03 field which allows passing along proof objects of chains that cannot introspect their consensus state (https://github.com/cosmos/ibc/pull/839)