### PR TITLE
Add deserialization for height

### DIFF
--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -54,7 +54,7 @@ bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 displaydoc = { version = "0.2", default-features = false }
-ibc-proto = { version = "0.37.0", default-features = false }
+ibc-proto = { version = "0.37.0", default-features = false, features = ["serde"] }
 ibc-types-domain-type = { version = "0.7.0", path = "../ibc-types-domain-type", default-features = false }
 ibc-types-identifier = { version = "0.7.0", path = "../ibc-types-identifier", default-features = false }
 ibc-types-timestamp = { version = "0.7.0", path = "../ibc-types-timestamp", default-features = false }

--- a/crates/ibc-types-core-client/src/height.rs
+++ b/crates/ibc-types-core-client/src/height.rs
@@ -12,7 +12,11 @@ use crate::error::Error;
 
 /// An IBC height, containing a revision number (epoch) and a revision height (block height).
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(try_from = "RawHeight", into = "RawHeight")
+)]
 pub struct Height {
     /// Previously known as "epoch"
     pub revision_number: u64,


### PR DESCRIPTION
Needed to Ics20Withdraw can be deserialized in the Penumbra wasm crate