### PR TITLE
ibc-types-core-client(mock): Support unfreezing an IBC client

### DIFF
--- a/crates/ibc-types-core-client/src/mock/client_state.rs
+++ b/crates/ibc-types-core-client/src/mock/client_state.rs
@@ -47,6 +47,13 @@ impl MockClientState {
             ..self
         }
     }
+
+    pub fn unfrozen(self) -> Self {
+        Self {
+            frozen_height: None,
+            ..self
+        }
+    }
 }
 
 impl Protobuf<RawMockClientState> for MockClientState {}

--- a/crates/ibc-types-lightclients-tendermint/src/client_state.rs
+++ b/crates/ibc-types-lightclients-tendermint/src/client_state.rs
@@ -196,6 +196,13 @@ impl ClientState {
         }
     }
 
+    pub fn unfrozen(self) -> Self {
+        Self {
+            frozen_height: None,
+            ..self
+        }
+    }
+
     /// Get the refresh time to ensure the state does not expire
     pub fn refresh_time(&self) -> Option<Duration> {
         Some(2 * self.trusting_period / 3)


### PR DESCRIPTION
Necessary to implement IBC unfreeze chain proposals in penumbra-zone/penumbra