### PR TITLE
Revert "ibc-types: use `ibc-proto-rs` fork and prepare release `0.11`"

### DIFF
--- a/ci/no-std-check/Cargo.toml
+++ b/ci/no-std-check/Cargo.toml
@@ -9,8 +9,7 @@ ibc-types = { path = "../../crates/ibc-types", default-features = false, feature
   "serde",
   "mocks-no-std",
 ] }
-# Forked until we have protojson support: https://github.com/cosmos/ibc-proto-rs/pull/166
-ibc-proto = { git = "https://github.com/penumbra-zone/ibc-proto-rs", default-features = false }
+ibc-proto = { version = "0.39.0", default-features = false }
 tendermint = { version = "0.34.0", default-features = false }
 tendermint-proto = { version = "0.34.0", default-features = false }
 tendermint-light-client-verifier = { version = "0.34.0", default-features = false, features = ["rust-crypto"] }

--- a/crates/ibc-types-core-channel/Cargo.toml
+++ b/crates/ibc-types-core-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-core-channel"
-version      = "0.11.0"
+version      = "0.10.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
@@ -53,18 +53,14 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-ibc-types-core-client = { version = "0.11.0", path = "../ibc-types-core-client", default-features = false }
-ibc-types-core-connection = { version = "0.11.0", path = "../ibc-types-core-connection", default-features = false }
-ibc-types-core-commitment = { version = "0.11.0", path = "../ibc-types-core-commitment", default-features = false }
-ibc-types-domain-type = { version = "0.11.0", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-identifier = { version = "0.11.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-timestamp = { version = "0.11.0", path = "../ibc-types-timestamp", default-features = false }
-
+ibc-types-core-client = { version = "0.10.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-core-connection = { version = "0.10.0", path = "../ibc-types-core-connection", default-features = false }
+ibc-types-core-commitment = { version = "0.10.0", path = "../ibc-types-core-commitment", default-features = false }
+ibc-types-domain-type = { version = "0.10.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-identifier = { version = "0.10.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-timestamp = { version = "0.10.0", path = "../ibc-types-timestamp", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-
-# Forked until we have protojson support: https://github.com/cosmos/ibc-proto-rs/pull/166
-ibc-proto = { git = "https://github.com/penumbra-zone/ibc-proto-rs", default-features = false }
-
+ibc-proto = { version = "0.39.0", default-features = false }
 ## for borsh encode or decode
 borsh = {version = "0.10.0", default-features = false, optional = true }
 bytes = { version = "1.2.1", default-features = false }
@@ -106,6 +102,6 @@ default-features = false
 [dev-dependencies]
 cfg-if = { version = "1.0.0" }
 env_logger = "0.10.0"
-ibc-types-core-client = { version = "0.11.0", path = "../ibc-types-core-client", features = ["mocks"] }
+ibc-types-core-client = { version = "0.10.0", path = "../ibc-types-core-client", features = ["mocks"] }
 test-log = { version = "0.2.10", features = ["trace"] }
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}

--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-core-client"
-version      = "0.11.0"
+version      = "0.10.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
@@ -54,11 +54,10 @@ bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 displaydoc = { version = "0.2", default-features = false }
-# Forked until we have protojson support: https://github.com/cosmos/ibc-proto-rs/pull/166
-ibc-proto = { git = "https://github.com/penumbra-zone/ibc-proto-rs", default-features = false }
-ibc-types-domain-type = { version = "0.11.0", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-identifier = { version = "0.11.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-timestamp = { version = "0.11.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-proto = { version = "0.39.0", default-features = false }
+ibc-types-domain-type = { version = "0.10.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-identifier = { version = "0.10.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-timestamp = { version = "0.10.0", path = "../ibc-types-timestamp", default-features = false }
 ics23 = { version = "0.11.0", default-features = false, features = ["host-functions"] }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }

--- a/crates/ibc-types-core-commitment/Cargo.toml
+++ b/crates/ibc-types-core-commitment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-core-commitment"
-version      = "0.11.0"
+version      = "0.10.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
@@ -55,15 +55,11 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-ibc-types-timestamp = { version = "0.11.0", path = "../ibc-types-timestamp", default-features = false }
-ibc-types-identifier = { version = "0.11.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-domain-type = { version = "0.11.0", path = "../ibc-types-domain-type", default-features = false }
-
+ibc-types-timestamp = { version = "0.10.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-identifier = { version = "0.10.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-domain-type = { version = "0.10.0", path = "../ibc-types-domain-type", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-
-# Forked until we have protojson support: https://github.com/cosmos/ibc-proto-rs/pull/166
-ibc-proto = { git = "https://github.com/penumbra-zone/ibc-proto-rs", default-features = false }
-
+ibc-proto = { version = "0.39.0", default-features = false }
 ics23 = { version = "0.11.0", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }

--- a/crates/ibc-types-core-connection/Cargo.toml
+++ b/crates/ibc-types-core-connection/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-core-connection"
-version      = "0.11.0"
+version      = "0.10.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
@@ -51,18 +51,17 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-ibc-types-timestamp = { version = "0.11.0", path = "../ibc-types-timestamp", default-features = false }
-ibc-types-core-commitment = { version = "0.11.0", path = "../ibc-types-core-commitment", default-features = false }
-ibc-types-identifier = { version = "0.11.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-domain-type = { version = "0.11.0", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-core-client = { version = "0.11.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-timestamp = { version = "0.10.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-core-commitment = { version = "0.10.0", path = "../ibc-types-core-commitment", default-features = false }
+ibc-types-identifier = { version = "0.10.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-domain-type = { version = "0.10.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-core-client = { version = "0.10.0", path = "../ibc-types-core-client", default-features = false }
 borsh = {version = "0.10.0", default-features = false, optional = true }
 bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 displaydoc = { version = "0.2", default-features = false }
-# Forked until we have protojson support: https://github.com/cosmos/ibc-proto-rs/pull/166
-ibc-proto = { git = "https://github.com/penumbra-zone/ibc-proto-rs", default-features = false }
+ibc-proto = { version = "0.39.0", default-features = false }
 ics23 = { version = "0.11.0", default-features = false, features = ["host-functions"] }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
@@ -96,5 +95,5 @@ env_logger = "0.10.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
 test-log = { version = "0.2.10", features = ["trace"] }
 cfg-if = { version = "1.0.0" }
-ibc-types-core-client = { version = "0.11.0", path = "../ibc-types-core-client", features = ["mocks"] }
+ibc-types-core-client = { version = "0.10.0", path = "../ibc-types-core-client", features = ["mocks"] }
 tracing = { version = "0.1.36", default-features = false }

--- a/crates/ibc-types-domain-type/Cargo.toml
+++ b/crates/ibc-types-domain-type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibc-types-domain-type"
-version = "0.11.0"
+version = "0.10.0"
 edition = "2021"
 license      = "Apache-2.0"
 publish = true

--- a/crates/ibc-types-identifier/Cargo.toml
+++ b/crates/ibc-types-identifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-identifier"
-version      = "0.11.0"
+version      = "0.10.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"

--- a/crates/ibc-types-lightclients-tendermint/Cargo.toml
+++ b/crates/ibc-types-lightclients-tendermint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-lightclients-tendermint"
-version      = "0.11.0"
+version      = "0.10.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
@@ -56,18 +56,14 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-ibc-types-timestamp = { version = "0.11.0", path = "../ibc-types-timestamp", default-features = false }
-ibc-types-identifier = { version = "0.11.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-domain-type = { version = "0.11.0", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-core-client = { version = "0.11.0", path = "../ibc-types-core-client", default-features = false }
-ibc-types-core-connection = { version = "0.11.0", path = "../ibc-types-core-connection", default-features = false }
-ibc-types-core-commitment = { version = "0.11.0", path = "../ibc-types-core-commitment", default-features = false }
-
+ibc-types-timestamp = { version = "0.10.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-identifier = { version = "0.10.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-domain-type = { version = "0.10.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-core-client = { version = "0.10.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-core-connection = { version = "0.10.0", path = "../ibc-types-core-connection", default-features = false }
+ibc-types-core-commitment = { version = "0.10.0", path = "../ibc-types-core-commitment", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-
-# Forked until we have protojson support: https://github.com/cosmos/ibc-proto-rs/pull/166
-ibc-proto = { git = "https://github.com/penumbra-zone/ibc-proto-rs", default-features = false }
-
+ibc-proto = { version = "0.39.0", default-features = false }
 ics23 = { version = "0.11.0", default-features = false, features = ["host-functions"] }
 time = { version = ">=0.3.0, <0.3.20", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }
@@ -123,4 +119,4 @@ tendermint-testgen = { version = "0.34.0" } # Needed for generating (synthetic) 
 parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }
 
-ibc-types-core-client = { version = "0.11.0", path = "../ibc-types-core-client", features = ["mocks"] }
+ibc-types-core-client = { version = "0.10.0", path = "../ibc-types-core-client", features = ["mocks"] }

--- a/crates/ibc-types-path/Cargo.toml
+++ b/crates/ibc-types-path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-path"
-version      = "0.11.0"
+version      = "0.10.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
@@ -46,9 +46,9 @@ mocks-no-std = ["cfg-if"]
 
 [dependencies]
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
-ibc-types-core-client = { version = "0.11.0", path = "../ibc-types-core-client", default-features = false }
-ibc-types-core-connection = { version = "0.11.0", path = "../ibc-types-core-connection", default-features = false }
-ibc-types-core-channel = { version = "0.11.0", path = "../ibc-types-core-channel", default-features = false }
+ibc-types-core-client = { version = "0.10.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-core-connection = { version = "0.10.0", path = "../ibc-types-core-connection", default-features = false }
+ibc-types-core-channel = { version = "0.10.0", path = "../ibc-types-core-channel", default-features = false }
 borsh = {version = "0.10.0", default-features = false, optional = true }
 bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }

--- a/crates/ibc-types-timestamp/Cargo.toml
+++ b/crates/ibc-types-timestamp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-timestamp"
-version      = "0.11.0"
+version      = "0.10.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"

--- a/crates/ibc-types-transfer/Cargo.toml
+++ b/crates/ibc-types-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-transfer"
-version      = "0.11.0"
+version      = "0.10.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"

--- a/crates/ibc-types/Cargo.toml
+++ b/crates/ibc-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types"
-version      = "0.11.0"
+version      = "0.10.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
@@ -56,13 +56,13 @@ mocks = [
 ]
 
 [dependencies]
-ibc-types-timestamp = { version = "0.11.0", path = "../ibc-types-timestamp", default-features = false }
-ibc-types-identifier = { version = "0.11.0", path = "../ibc-types-identifier", default-features = false }
-ibc-types-domain-type = { version = "0.11.0", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-core-client = { version = "0.11.0", path = "../ibc-types-core-client", default-features = false }
-ibc-types-core-connection = { version = "0.11.0", path = "../ibc-types-core-connection", default-features = false }
-ibc-types-core-channel = { version = "0.11.0", path = "../ibc-types-core-channel", default-features = false }
-ibc-types-core-commitment = { version = "0.11.0", path = "../ibc-types-core-commitment", default-features = false }
-ibc-types-lightclients-tendermint = { version = "0.11.0", path = "../ibc-types-lightclients-tendermint", default-features = false }
-ibc-types-path = { version = "0.11.0", path = "../ibc-types-path", default-features = false }
-ibc-types-transfer = { version = "0.11.0", path = "../ibc-types-transfer", default-features = false }
+ibc-types-timestamp = { version = "0.10.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-identifier = { version = "0.10.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-domain-type = { version = "0.10.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-core-client = { version = "0.10.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-core-connection = { version = "0.10.0", path = "../ibc-types-core-connection", default-features = false }
+ibc-types-core-channel = { version = "0.10.0", path = "../ibc-types-core-channel", default-features = false }
+ibc-types-core-commitment = { version = "0.10.0", path = "../ibc-types-core-commitment", default-features = false }
+ibc-types-lightclients-tendermint = { version = "0.10.0", path = "../ibc-types-lightclients-tendermint", default-features = false }
+ibc-types-path = { version = "0.10.0", path = "../ibc-types-path", default-features = false }
+ibc-types-transfer = { version = "0.10.0", path = "../ibc-types-transfer", default-features = false }


### PR DESCRIPTION
Reverts penumbra-zone/ibc-types#78

We should just wait for the upstream to be merged