### PR TITLE
ibc-types-lightclients-tendermint: add more stateless validaton for validator set

### DIFF
--- a/crates/ibc-types-lightclients-tendermint/src/error.rs
+++ b/crates/ibc-types-lightclients-tendermint/src/error.rs
@@ -126,6 +126,11 @@ pub enum Error {
         header_chain_id: String,
         chain_id: String,
     },
+    /// The given hash of the validators does not matches the given hash in the signed header. Expected: `{signed_header_validators_hash}`, got: `{validators_hash}`
+    MismatchValidatorsHashes {
+        validators_hash: Hash,
+        signed_header_validators_hash: Hash,
+    },
     /// invalid raw client id: `{client_id}`
     InvalidRawClientId { client_id: String },
 }

--- a/crates/ibc-types-lightclients-tendermint/src/header.rs
+++ b/crates/ibc-types-lightclients-tendermint/src/header.rs
@@ -114,6 +114,13 @@ impl TryFrom<RawHeader> for Header {
             });
         }
 
+        if header.validator_set.hash() != header.signed_header.header.validators_hash {
+            return Err(Error::MismatchValidatorsHashes {
+                signed_header_validators_hash: header.signed_header.header.validators_hash,
+                validators_hash: header.validator_set.hash(),
+            });
+        }
+
         Ok(header)
     }
 }


### PR DESCRIPTION
In the penumbra ibc-async implementation, this check is redundant (the state machine checks this), but since this is a stateless validation of a domain type it should exist in ibc-types.