### PR TITLE
provide feature to use eyre instead of anyhow

### DIFF
--- a/crates/ibc-types-core-channel/Cargo.toml
+++ b/crates/ibc-types-core-channel/Cargo.toml
@@ -18,7 +18,7 @@ publish	= true
 all-features = true
 
 [features]
-default = ["std"]
+default = ["std", "anyhow"]
 std = [
     "ibc-types-timestamp/std",
     "ibc-types-identifier/std",
@@ -52,6 +52,17 @@ upgrade_client = []
 mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
+anyhow = [
+    "dep:anyhow",
+    "ibc-types-core-commitment/anyhow",
+    "ibc-types-domain-type/anyhow",
+]
+eyre = [
+    "dep:eyre",
+    "ibc-types-core-commitment/eyre",
+    "ibc-types-domain-type/eyre",
+]
+
 [dependencies]
 ibc-types-core-client = { version = "0.13.0", path = "../ibc-types-core-client", default-features = false }
 ibc-types-core-connection = { version = "0.13.0", path = "../ibc-types-core-connection", default-features = false }
@@ -84,7 +95,9 @@ subtle-encoding = { version = "0.5", default-features = false }
 time = { version = "0.3", default-features = false }
 tracing = { version = "0.1.36", default-features = false }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
-anyhow = { version = "1", default-features = false }
+
+anyhow = { version = "1", default-features = false, optional = true }
+eyre = { version = "0.6.12", optional = true }
 
 [dependencies.tendermint]
 version = "0.34.0"

--- a/crates/ibc-types-core-channel/src/lib.rs
+++ b/crates/ibc-types-core-channel/src/lib.rs
@@ -7,6 +7,14 @@ extern crate alloc;
 #[cfg(any(test, feature = "std"))]
 extern crate std;
 
+#[cfg(all(feature = "anyhow", feature = "eyre"))]
+compile_error!("feature \"anyhow\" and feature \"eyre\" cannot be enabled at the same time");
+
+#[cfg(feature = "anyhow")]
+extern crate anyhow;
+#[cfg(feature = "eyre")]
+extern crate eyre as anyhow;
+
 pub mod channel;
 pub mod packet;
 

--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -17,7 +17,7 @@ description  = """
 all-features = true
 
 [features]
-default = ["std"]
+default = ["std", "anyhow"]
 std = [
     "bytes/std",
     "displaydoc/std",
@@ -34,6 +34,10 @@ std = [
     "tendermint/clock",
     "tendermint/std",
 ]
+
+anyhow = ["dep:anyhow"]
+eyre = ["dep:eyre"]
+
 parity-scale-codec = ["dep:parity-scale-codec", "dep:scale-info"]
 borsh = ["dep:borsh"]
 
@@ -69,7 +73,10 @@ serde_json = { version = "1", default-features = false, optional = true }
 sha2 = { version = "0.10.6", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false }
 time = { version = "0.3", default-features = false }
-anyhow = { version = "1", default-features = false }
+
+# anyhow and eyre are mutually exclusive features
+anyhow = { version = "1", default-features = false, optional = true }
+eyre = { version = "0.6.12", optional = true}
 
 [dependencies.tendermint]
 version = "0.34.0"

--- a/crates/ibc-types-core-commitment/Cargo.toml
+++ b/crates/ibc-types-core-commitment/Cargo.toml
@@ -18,7 +18,7 @@ publish	= true
 all-features = true
 
 [features]
-default = ["std"]
+default = ["std", "anyhow"]
 std = [ 
     "ibc-types-timestamp/std",
     "ibc-types-identifier/std",
@@ -54,6 +54,15 @@ upgrade_client = []
 mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
+anyhow = [
+    "dep:anyhow",
+    "ibc-types-domain-type/anyhow",
+]
+eyre = [
+    "dep:eyre",
+    "ibc-types-domain-type/eyre",
+]
+
 [dependencies]
 ibc-types-timestamp = { version = "0.13.0", path = "../ibc-types-timestamp", default-features = false }
 ibc-types-identifier = { version = "0.13.0", path = "../ibc-types-identifier", default-features = false }
@@ -85,8 +94,10 @@ scale-info = { version = "2.1.2", default-features = false, features = ["derive"
 borsh = {version = "0.10.0", default-features = false, optional = true }
 parking_lot = { version = "0.12.1", default-features = false, optional = true }
 cfg-if = { version = "1.0.0", optional = true }
-anyhow = "1"
 hex = { version = "0.4.3", default-features = false }
+
+anyhow = { version = "1", optional = true }
+eyre = { version = "0.6.12", optional = true}
 
 [dependencies.tendermint]
 version = "0.34.0"

--- a/crates/ibc-types-core-commitment/src/lib.rs
+++ b/crates/ibc-types-core-commitment/src/lib.rs
@@ -7,6 +7,14 @@ extern crate alloc;
 #[cfg(any(test, feature = "std"))]
 extern crate std;
 
+#[cfg(all(feature = "anyhow", feature = "eyre"))]
+compile_error!("feature \"anyhow\" and feature \"eyre\" cannot be enabled at the same time");
+
+#[cfg(feature = "anyhow")]
+extern crate anyhow;
+#[cfg(feature = "eyre")]
+extern crate eyre as anyhow;
+
 mod prelude;
 
 mod error;

--- a/crates/ibc-types-core-connection/Cargo.toml
+++ b/crates/ibc-types-core-connection/Cargo.toml
@@ -18,7 +18,7 @@ publish	= true
 all-features = true
 
 [features]
-default = ["std"]
+default = ["std", "anyhow"]
 std = [
     "bytes/std",
     "displaydoc/std",
@@ -50,6 +50,17 @@ upgrade_client = []
 mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
+anyhow = [
+    "dep:anyhow",
+    "ibc-types-core-commitment/anyhow",
+    "ibc-types-domain-type/anyhow",
+]
+eyre = [
+    "dep:eyre",
+    "ibc-types-core-commitment/eyre",
+    "ibc-types-domain-type/eyre",
+]
+
 [dependencies]
 ibc-types-timestamp = { version = "0.13.0", path = "../ibc-types-timestamp", default-features = false }
 ibc-types-core-commitment = { version = "0.13.0", path = "../ibc-types-core-commitment", default-features = false }
@@ -75,7 +86,8 @@ serde_json = { version = "1", default-features = false, optional = true }
 sha2 = { version = "0.10.6", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false }
 time = { version = "0.3", default-features = false }
-anyhow = { version = "1", default-features = false }
+anyhow = { version = "1", default-features = false, optional = true }
+eyre = { version = "0.6.12", optional = true }
 
 [dependencies.tendermint]
 version = "0.34.0"

--- a/crates/ibc-types-domain-type/Cargo.toml
+++ b/crates/ibc-types-domain-type/Cargo.toml
@@ -18,7 +18,13 @@ all-features = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["anyhow"]
+anyhow = ["dep:anyhow"]
+eyre = ["dep:eyre"]
+
 [dependencies]
-anyhow = { version = "1", default-features = false }
+anyhow = { version = "1", default-features = false, optional = true }
+eyre = { version = "0.6.12", optional = true}
 prost = { version = "0.12", default-features = false }
 bytes = { version = "1.2.1", default-features = false }

--- a/crates/ibc-types-domain-type/src/lib.rs
+++ b/crates/ibc-types-domain-type/src/lib.rs
@@ -7,6 +7,14 @@ extern crate alloc;
 #[cfg(any(test, feature = "std"))]
 extern crate std;
 
+#[cfg(all(feature = "anyhow", feature = "eyre"))]
+compile_error!("feature \"anyhow\" and feature \"eyre\" cannot be enabled at the same time");
+
+#[cfg(feature = "anyhow")]
+extern crate anyhow;
+#[cfg(feature = "eyre")]
+extern crate eyre as anyhow;
+
 mod prelude;
 use prelude::*;
 

--- a/crates/ibc-types-lightclients-tendermint/Cargo.toml
+++ b/crates/ibc-types-lightclients-tendermint/Cargo.toml
@@ -18,7 +18,7 @@ publish	= true
 all-features = true
 
 [features]
-default = ["std"]
+default = ["std", "anyhow"]
 std = [ 
     "ibc-types-timestamp/std",
     "ibc-types-identifier/std",
@@ -55,6 +55,21 @@ upgrade_client = []
 mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
+anyhow = [
+    "dep:anyhow",
+    "ibc-types-core-client/anyhow",
+    "ibc-types-core-commitment/anyhow",
+    "ibc-types-core-connection/anyhow",
+    "ibc-types-domain-type/anyhow",
+]
+eyre = [
+    "dep:eyre",
+    "ibc-types-core-client/eyre",
+    "ibc-types-core-commitment/eyre",
+    "ibc-types-core-connection/eyre",
+    "ibc-types-domain-type/eyre",
+]
+
 [dependencies]
 ibc-types-timestamp = { version = "0.13.0", path = "../ibc-types-timestamp", default-features = false }
 ibc-types-identifier = { version = "0.13.0", path = "../ibc-types-identifier", default-features = false }
@@ -89,7 +104,9 @@ scale-info = { version = "2.1.2", default-features = false, features = ["derive"
 borsh = {version = "0.10.0", default-features = false, optional = true }
 parking_lot = { version = "0.12.1", default-features = false, optional = true }
 cfg-if = { version = "1.0.0", optional = true }
-anyhow = { version = "1", default-features = false }
+
+anyhow = { version = "1", default-features = false, optional = true }
+eyre = { version = "0.6.12", optional = true }
 
 [dependencies.tendermint]
 version = "0.34.0"


### PR DESCRIPTION
This PR adds the `anyhow` and `eyre` features to all crates using anyhow for errors. `anyhow` is added to `default` so nothing changes for standard workflows. Caveat: `anyhow` does not allow to opt out of `std`.

What do you think? Does this fit into your design?

Background: I want to use `eyre` in `cnidarium` and other crates that astria's Sequencer depends on (hence this PR targetting `ibc-types`, which are a blocker for cnidarium to migrate). We are using an eyre error hook [1] in our services to customize our error `Display` formatting in order to get full source-chains emitted in tracing events. There are two reasons for this:

1. Tracing implements `Value` only for `dyn std::error::Error`. So in order to get full error backtraces (while avoiding debug formatting), one needs to convert the anyhow error to a trait object using a clunky `error = AsRef::<dyn std::error::Error>::as_ref(&the_error)`.
2. Even if one correctly converted to a error trait-object, some tracing-subscriber formatters (namely the `Json` one) don't follow the source-chain, only printing the top-most context. There is a PR sitting idle for 6 months now and is not being merged [2].

Because of these 2 issues we customized the error hook lest we miss out on important information.

1: https://github.com/astriaorg/astria/blob/6f13e7f126c7df35c764cae309f79fa28090028c/crates/astria-eyre/src/lib.rs#L27
2: https://github.com/tokio-rs/tracing/pull/2797

