### PR TITLE
zellic audit remediations

### DIFF
--- a/crates/ibc-types-lightclients-tendermint/src/client_state.rs
+++ b/crates/ibc-types-lightclients-tendermint/src/client_state.rs
@@ -79,6 +79,10 @@ impl ClientState {
             });
         }
 
+        if chain_id.as_str() == "" {
+            return Err(Error::ChainIdEmpty);
+        }
+
         // `TrustThreshold` is guaranteed to be in the range `[0, 1)`, but a `TrustThreshold::ZERO`
         // value is invalid in this context
         if trust_level == TrustThreshold::ZERO {

--- a/crates/ibc-types-lightclients-tendermint/src/error.rs
+++ b/crates/ibc-types-lightclients-tendermint/src/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
         len: usize,
         max_len: usize,
     },
+    /// Chain ID cannot be empty
+    ChainIdEmpty,
     /// invalid header, failed basic validation: `{reason}`, error: `{error}`
     InvalidHeader {
         reason: String,


### PR DESCRIPTION
This PR adds a validation rule to the tendermint `ClientState` struct to forbid empty chain ids. 