### PR TITLE
update to ibc-proto 0.46, tendermint 0.37

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ members = [
 exclude = [
     "ci/no-std-check",
 ]
+
+[workspace.dependencies]
+ibc-proto = { version = "0.46.0", default-features = false }

--- a/crates/ibc-types-core-channel/Cargo.toml
+++ b/crates/ibc-types-core-channel/Cargo.toml
@@ -60,7 +60,7 @@ ibc-types-domain-type = { version = "0.13.0", path = "../ibc-types-domain-type",
 ibc-types-identifier = { version = "0.13.0", path = "../ibc-types-identifier", default-features = false }
 ibc-types-timestamp = { version = "0.13.0", path = "../ibc-types-timestamp", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.42.0", default-features = false }
+ibc-proto = {workspace = true}
 ## for borsh encode or decode
 borsh = {version = "0.10.0", default-features = false, optional = true }
 bytes = { version = "1.2.1", default-features = false }
@@ -87,15 +87,15 @@ scale-info = { version = "2.1.2", default-features = false, features = ["derive"
 anyhow = { version = "1", default-features = false }
 
 [dependencies.tendermint]
-version = "0.34.0"
+version = "0.37.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.34.0"
+version = "0.37.0"
 default-features = false
 
 [dependencies.tendermint-testgen]
-version = "0.34.0"
+version = "0.37.0"
 optional = true
 default-features = false
 

--- a/crates/ibc-types-core-channel/src/events/channel.rs
+++ b/crates/ibc-types-core-channel/src/events/channel.rs
@@ -56,21 +56,21 @@ impl TryFrom<Event> for OpenInit {
         let mut version = None;
 
         for attr in event.attributes {
-            match attr.key.as_ref() {
+            match attr.key_str().unwrap() {
                 "port_id" => {
-                    port_id = Some(PortId(attr.value));
+                    port_id = Some(PortId(attr.value_str().unwrap().to_owned()));
                 }
                 "channel_id" => {
-                    channel_id = Some(ChannelId(attr.value));
+                    channel_id = Some(ChannelId(attr.value_str().unwrap().to_owned()));
                 }
                 "counterparty_port_id" => {
-                    counterparty_port_id = Some(PortId(attr.value));
+                    counterparty_port_id = Some(PortId(attr.value_str().unwrap().to_owned()));
                 }
                 "connection_id" => {
-                    connection_id = Some(ConnectionId(attr.value));
+                    connection_id = Some(ConnectionId(attr.value_str().unwrap().to_owned()));
                 }
                 "version" => {
-                    version = Some(Version(attr.value));
+                    version = Some(Version(attr.value_str().unwrap().to_owned()));
                 }
                 unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
             }
@@ -136,24 +136,24 @@ impl TryFrom<Event> for OpenTry {
         let mut version = None;
 
         for attr in event.attributes {
-            match attr.key.as_ref() {
+            match attr.key_str().unwrap() {
                 "port_id" => {
-                    port_id = Some(PortId(attr.value));
+                    port_id = Some(PortId(attr.value_str().unwrap().to_owned()));
                 }
                 "channel_id" => {
-                    channel_id = Some(ChannelId(attr.value));
+                    channel_id = Some(ChannelId(attr.value_str().unwrap().to_owned()));
                 }
                 "counterparty_port_id" => {
-                    counterparty_port_id = Some(PortId(attr.value));
+                    counterparty_port_id = Some(PortId(attr.value_str().unwrap().to_owned()));
                 }
                 "counterparty_channel_id" => {
-                    counterparty_channel_id = Some(ChannelId(attr.value));
+                    counterparty_channel_id = Some(ChannelId(attr.value_str().unwrap().to_owned()));
                 }
                 "connection_id" => {
-                    connection_id = Some(ConnectionId(attr.value));
+                    connection_id = Some(ConnectionId(attr.value_str().unwrap().to_owned()));
                 }
                 "version" => {
-                    version = Some(Version(attr.value));
+                    version = Some(Version(attr.value_str().unwrap().to_owned()));
                 }
                 unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
             }
@@ -218,21 +218,21 @@ impl TryFrom<Event> for OpenAck {
         let mut connection_id = None;
 
         for attr in event.attributes {
-            match attr.key.as_ref() {
+            match attr.key_str().unwrap() {
                 "port_id" => {
-                    port_id = Some(PortId(attr.value));
+                    port_id = Some(PortId(attr.value_str().unwrap().to_owned()));
                 }
                 "channel_id" => {
-                    channel_id = Some(ChannelId(attr.value));
+                    channel_id = Some(ChannelId(attr.value_str().unwrap().to_owned()));
                 }
                 "counterparty_port_id" => {
-                    counterparty_port_id = Some(PortId(attr.value));
+                    counterparty_port_id = Some(PortId(attr.value_str().unwrap().to_owned()));
                 }
                 "counterparty_channel_id" => {
-                    counterparty_channel_id = Some(ChannelId(attr.value));
+                    counterparty_channel_id = Some(ChannelId(attr.value_str().unwrap().to_owned()));
                 }
                 "connection_id" => {
-                    connection_id = Some(ConnectionId(attr.value));
+                    connection_id = Some(ConnectionId(attr.value_str().unwrap().to_owned()));
                 }
                 unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
             }
@@ -296,21 +296,21 @@ impl TryFrom<Event> for OpenConfirm {
         let mut connection_id = None;
 
         for attr in event.attributes {
-            match attr.key.as_ref() {
+            match attr.key_str().unwrap() {
                 "port_id" => {
-                    port_id = Some(PortId(attr.value));
+                    port_id = Some(PortId(attr.value_str().unwrap().to_owned()));
                 }
                 "channel_id" => {
-                    channel_id = Some(ChannelId(attr.value));
+                    channel_id = Some(ChannelId(attr.value_str().unwrap().to_owned()));
                 }
                 "counterparty_port_id" => {
-                    counterparty_port_id = Some(PortId(attr.value));
+                    counterparty_port_id = Some(PortId(attr.value_str().unwrap().to_owned()));
                 }
                 "counterparty_channel_id" => {
-                    counterparty_channel_id = Some(ChannelId(attr.value));
+                    counterparty_channel_id = Some(ChannelId(attr.value_str().unwrap().to_owned()));
                 }
                 "connection_id" => {
-                    connection_id = Some(ConnectionId(attr.value));
+                    connection_id = Some(ConnectionId(attr.value_str().unwrap().to_owned()));
                 }
                 unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
             }
@@ -374,21 +374,21 @@ impl TryFrom<Event> for CloseInit {
         let mut connection_id = None;
 
         for attr in event.attributes {
-            match attr.key.as_ref() {
+            match attr.key_str().unwrap() {
                 "port_id" => {
-                    port_id = Some(PortId(attr.value));
+                    port_id = Some(PortId(attr.value_str().unwrap().to_owned()));
                 }
                 "channel_id" => {
-                    channel_id = Some(ChannelId(attr.value));
+                    channel_id = Some(ChannelId(attr.value_str().unwrap().to_owned()));
                 }
                 "counterparty_port_id" => {
-                    counterparty_port_id = Some(PortId(attr.value));
+                    counterparty_port_id = Some(PortId(attr.value_str().unwrap().to_owned()));
                 }
                 "counterparty_channel_id" => {
-                    counterparty_channel_id = Some(ChannelId(attr.value));
+                    counterparty_channel_id = Some(ChannelId(attr.value_str().unwrap().to_owned()));
                 }
                 "connection_id" => {
-                    connection_id = Some(ConnectionId(attr.value));
+                    connection_id = Some(ConnectionId(attr.value_str().unwrap().to_owned()));
                 }
                 unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
             }
@@ -452,21 +452,21 @@ impl TryFrom<Event> for CloseConfirm {
         let mut connection_id = None;
 
         for attr in event.attributes {
-            match attr.key.as_ref() {
+            match attr.key_str().unwrap() {
                 "port_id" => {
-                    port_id = Some(PortId(attr.value));
+                    port_id = Some(PortId(attr.value_str().unwrap().to_owned()));
                 }
                 "channel_id" => {
-                    channel_id = Some(ChannelId(attr.value));
+                    channel_id = Some(ChannelId(attr.value_str().unwrap().to_owned()));
                 }
                 "counterparty_port_id" => {
-                    counterparty_port_id = Some(PortId(attr.value));
+                    counterparty_port_id = Some(PortId(attr.value_str().unwrap().to_owned()));
                 }
                 "counterparty_channel_id" => {
-                    counterparty_channel_id = Some(ChannelId(attr.value));
+                    counterparty_channel_id = Some(ChannelId(attr.value_str().unwrap().to_owned()));
                 }
                 "connection_id" => {
-                    connection_id = Some(ConnectionId(attr.value));
+                    connection_id = Some(ConnectionId(attr.value_str().unwrap().to_owned()));
                 }
                 unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
             }

--- a/crates/ibc-types-core-channel/src/events/tests.rs
+++ b/crates/ibc-types-core-channel/src/events/tests.rs
@@ -135,12 +135,18 @@ fn ibc_to_abci_channel_events() {
         assert_eq!(t.kind, t.event.kind);
         assert_eq!(t.expected_keys.len(), t.event.attributes.len());
         for (i, e) in t.event.attributes.iter().enumerate() {
-            assert_eq!(e.key, t.expected_keys[i], "key mismatch for {:?}", t.kind,);
+            assert_eq!(
+                e.key_str().unwrap(),
+                t.expected_keys[i],
+                "key mismatch for {:?}",
+                t.kind,
+            );
         }
         assert_eq!(t.expected_values.len(), t.event.attributes.len());
         for (i, e) in t.event.attributes.iter().enumerate() {
             assert_eq!(
-                e.value, t.expected_values[i],
+                e.value_str().unwrap(),
+                t.expected_values[i],
                 "value mismatch for {:?}",
                 t.kind,
             );

--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -54,7 +54,7 @@ bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 displaydoc = { version = "0.2", default-features = false }
-ibc-proto = { version = "0.42.0", default-features = false }
+ibc-proto = {workspace = true}
 ibc-types-domain-type = { version = "0.13.0", path = "../ibc-types-domain-type", default-features = false }
 ibc-types-identifier = { version = "0.13.0", path = "../ibc-types-identifier", default-features = false }
 ibc-types-timestamp = { version = "0.13.0", path = "../ibc-types-timestamp", default-features = false }
@@ -72,11 +72,11 @@ time = { version = "0.3", default-features = false }
 anyhow = { version = "1", default-features = false }
 
 [dependencies.tendermint]
-version = "0.34.0"
+version = "0.37.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.34.0"
+version = "0.37.0"
 default-features = false
 
 [dev-dependencies]

--- a/crates/ibc-types-core-client/src/events.rs
+++ b/crates/ibc-types-core-client/src/events.rs
@@ -95,19 +95,20 @@ impl TryFrom<Event> for CreateClient {
         let mut consensus_height = None;
 
         for attr in event.attributes {
-            match attr.key.as_ref() {
+            match attr.key_str().unwrap() {
                 "client_id" => {
-                    client_id = Some(ClientId(attr.value));
+                    client_id = Some(ClientId(attr.value_str().unwrap().to_owned()));
                 }
                 "client_type" => {
-                    client_type = Some(ClientType(attr.value));
+                    client_type = Some(ClientType(attr.value_str().unwrap().to_owned()));
                 }
                 "consensus_height" => {
-                    consensus_height =
-                        Some(attr.value.parse().map_err(|e| Error::ParseHeight {
+                    consensus_height = Some(attr.value_str().unwrap().parse().map_err(|e| {
+                        Error::ParseHeight {
                             key: "consensus_height",
                             e,
-                        })?);
+                        }
+                    })?);
                 }
                 unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
             }
@@ -167,23 +168,24 @@ impl TryFrom<Event> for UpdateClient {
         let mut header = None;
 
         for attr in value.attributes {
-            match attr.key.as_ref() {
+            match attr.key_str().unwrap() {
                 "client_id" => {
-                    client_id = Some(ClientId(attr.value));
+                    client_id = Some(ClientId(attr.value_str().unwrap().to_owned()));
                 }
                 "client_type" => {
-                    client_type = Some(ClientType(attr.value));
+                    client_type = Some(ClientType(attr.value_str().unwrap().to_owned()));
                 }
                 "consensus_height" => {
-                    consensus_height =
-                        Some(attr.value.parse().map_err(|e| Error::ParseHeight {
+                    consensus_height = Some(attr.value_str().unwrap().parse().map_err(|e| {
+                        Error::ParseHeight {
                             key: "consensus_height",
                             e,
-                        })?);
+                        }
+                    })?);
                 }
                 "header" => {
                     header = Some(
-                        hex::decode(attr.value)
+                        hex::decode(attr.value_str().unwrap())
                             .map_err(|e| Error::ParseHex { key: "header", e })?,
                     );
                 }
@@ -238,12 +240,12 @@ impl TryFrom<Event> for ClientMisbehaviour {
         let mut client_type = None;
 
         for attr in value.attributes {
-            match attr.key.as_ref() {
+            match attr.key_str().unwrap() {
                 "client_id" => {
-                    client_id = Some(ClientId(attr.value));
+                    client_id = Some(ClientId(attr.value_str().unwrap().to_owned()));
                 }
                 "client_type" => {
-                    client_type = Some(ClientType(attr.value));
+                    client_type = Some(ClientType(attr.value_str().unwrap().to_owned()));
                 }
                 unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
             }
@@ -295,19 +297,20 @@ impl TryFrom<Event> for UpgradeClient {
         let mut consensus_height = None;
 
         for attr in value.attributes {
-            match attr.key.as_ref() {
+            match attr.key_str().unwrap() {
                 "client_id" => {
-                    client_id = Some(ClientId(attr.value));
+                    client_id = Some(ClientId(attr.value_str().unwrap().to_owned()));
                 }
                 "client_type" => {
-                    client_type = Some(ClientType(attr.value));
+                    client_type = Some(ClientType(attr.value_str().unwrap().to_owned()));
                 }
                 "consensus_height" => {
-                    consensus_height =
-                        Some(attr.value.parse().map_err(|e| Error::ParseHeight {
+                    consensus_height = Some(attr.value_str().unwrap().parse().map_err(|e| {
+                        Error::ParseHeight {
                             key: "consensus_height",
                             e,
-                        })?);
+                        }
+                    })?);
                 }
                 unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
             }

--- a/crates/ibc-types-core-commitment/Cargo.toml
+++ b/crates/ibc-types-core-commitment/Cargo.toml
@@ -59,7 +59,7 @@ ibc-types-timestamp = { version = "0.13.0", path = "../ibc-types-timestamp", def
 ibc-types-identifier = { version = "0.13.0", path = "../ibc-types-identifier", default-features = false }
 ibc-types-domain-type = { version = "0.13.0", path = "../ibc-types-domain-type", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.42.0", default-features = false }
+ibc-proto = {workspace = true}
 ics23 = { version = "0.11.0", default-features = false, features = ["host-functions"] }
 time = { version = "0.3", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }
@@ -89,20 +89,20 @@ anyhow = "1"
 hex = { version = "0.4.3", default-features = false }
 
 [dependencies.tendermint]
-version = "0.34.0"
+version = "0.37.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.34.0"
+version = "0.37.0"
 default-features = false
 
 [dependencies.tendermint-light-client-verifier]
-version = "0.34.0"
+version = "0.37.0"
 default-features = false
 features = ["rust-crypto"]
 
 [dependencies.tendermint-testgen]
-version = "0.34.0"
+version = "0.37.0"
 optional = true
 default-features = false
 
@@ -111,8 +111,8 @@ env_logger = "0.10.0"
 rstest = "0.16.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
 test-log = { version = "0.2.10", features = ["trace"] }
-tendermint-rpc = { version = "0.34.0", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { version = "0.34.0" } # Needed for generating (synthetic) light blocks.
+tendermint-rpc = { version = "0.37.0", features = ["http-client", "websocket-client"] }
+tendermint-testgen = { version = "0.37.0" } # Needed for generating (synthetic) light blocks.
 parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }
 

--- a/crates/ibc-types-core-connection/Cargo.toml
+++ b/crates/ibc-types-core-connection/Cargo.toml
@@ -61,7 +61,7 @@ bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 displaydoc = { version = "0.2", default-features = false }
-ibc-proto = { version = "0.42.0", default-features = false }
+ibc-proto = {workspace = true}
 ics23 = { version = "0.11.0", default-features = false, features = ["host-functions"] }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
@@ -78,15 +78,15 @@ time = { version = "0.3", default-features = false }
 anyhow = { version = "1", default-features = false }
 
 [dependencies.tendermint]
-version = "0.34.0"
+version = "0.37.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.34.0"
+version = "0.37.0"
 default-features = false
 
 [dependencies.tendermint-testgen]
-version = "0.34.0"
+version = "0.37.0"
 optional = true
 default-features = false
 

--- a/crates/ibc-types-lightclients-tendermint/Cargo.toml
+++ b/crates/ibc-types-lightclients-tendermint/Cargo.toml
@@ -63,7 +63,7 @@ ibc-types-core-client = { version = "0.13.0", path = "../ibc-types-core-client",
 ibc-types-core-connection = { version = "0.13.0", path = "../ibc-types-core-connection", default-features = false }
 ibc-types-core-commitment = { version = "0.13.0", path = "../ibc-types-core-commitment", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.42.0", default-features = false }
+ibc-proto = {workspace = true}
 ics23 = { version = "0.11.0", default-features = false, features = ["host-functions"] }
 time = { version = "0.3", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }
@@ -92,20 +92,20 @@ cfg-if = { version = "1.0.0", optional = true }
 anyhow = { version = "1", default-features = false }
 
 [dependencies.tendermint]
-version = "0.34.0"
+version = "0.37.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.34.0"
+version = "0.37.0"
 default-features = false
 
 [dependencies.tendermint-light-client-verifier]
-version = "0.34.0"
+version = "0.37.0"
 default-features = false
 features = ["rust-crypto"]
 
 [dependencies.tendermint-testgen]
-version = "0.34.0"
+version = "0.37.0"
 optional = true
 default-features = false
 
@@ -114,8 +114,8 @@ env_logger = "0.10.0"
 rstest = "0.16.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
 test-log = { version = "0.2.10", features = ["trace"] }
-tendermint-rpc = { version = "0.34.0", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { version = "0.34.0" } # Needed for generating (synthetic) light blocks.
+tendermint-rpc = { version = "0.37.0", features = ["http-client", "websocket-client"] }
+tendermint-testgen = { version = "0.37.0" } # Needed for generating (synthetic) light blocks.
 parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }
 

--- a/crates/ibc-types-path/Cargo.toml
+++ b/crates/ibc-types-path/Cargo.toml
@@ -63,9 +63,9 @@ serde_derive = { version = "1.0.104", default-features = false, optional = true 
 serde_json = { version = "1", default-features = false, optional = true }
 subtle-encoding = { version = "0.5", default-features = false }
 time = { version = "0.3", default-features = false }
-tendermint = { version = "0.34.0", default-features = false }
-tendermint-proto = { version = "0.34.0", default-features = false }
-tendermint-testgen = { version = "0.34.0", default-features = false, optional = true }
+tendermint = { version = "0.37.0", default-features = false }
+tendermint-proto = { version = "0.37.0", default-features = false }
+tendermint-testgen = { version = "0.37.0", default-features = false, optional = true }
 
 [dev-dependencies]
 cfg-if = { version = "1.0.0" }

--- a/crates/ibc-types-timestamp/Cargo.toml
+++ b/crates/ibc-types-timestamp/Cargo.toml
@@ -55,9 +55,9 @@ serde_derive = { version = "1.0.104", default-features = false, optional = true 
 serde_json = { version = "1", default-features = false, optional = true }
 subtle-encoding = { version = "0.5", default-features = false }
 time = { version = "0.3", default-features = false }
-tendermint = { version = "0.34.0", default-features = false }
-tendermint-proto = { version = "0.34.0", default-features = false }
-tendermint-testgen = { version = "0.34.0", default-features = false, optional = true }
+tendermint = { version = "0.37.0", default-features = false }
+tendermint-proto = { version = "0.37.0", default-features = false }
+tendermint-testgen = { version = "0.37.0", default-features = false, optional = true }
 
 [dev-dependencies]
 cfg-if = { version = "1.0.0" }


### PR DESCRIPTION
This involved adding a lot of unfortunate `.unwrap()` calls that could probably be rethinked later.

Adding them isn't any worse than the status quo, I think, it just moves where the panic happens further up the stack. The [tendermint 0.36](https://github.com/informalsystems/tendermint-rs/releases/tag/v0.36.0) API change just made the edge case more obvious.