### PR TITLE
bump prost, tendermint, ibc-proto, ics23

### DIFF
--- a/crates/ibc-types-core-channel/Cargo.toml
+++ b/crates/ibc-types-core-channel/Cargo.toml
@@ -60,19 +60,19 @@ ibc-types-domain-type = { version = "0.14.1", path = "../ibc-types-domain-type",
 ibc-types-identifier = { version = "0.14.1", path = "../ibc-types-identifier", default-features = false }
 ibc-types-timestamp = { version = "0.14.1", path = "../ibc-types-timestamp", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.42.2", default-features = false }
+ibc-proto = { version = "0.51.1", default-features = false }
 ## for borsh encode or decode
 borsh = {version = "0.10.0", default-features = false, optional = true }
 bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 displaydoc = { version = "0.2", default-features = false }
-ics23 = { version = "0.11.3", default-features = false, features = ["host-functions"] }
+ics23 = { version = "0.12.0", default-features = false, features = ["host-functions"] }
 num-traits = { version = "0.2.15", default-features = false }
 ## for codec encode or decode
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
 parking_lot = { version = "0.12.1", default-features = false, optional = true }
-prost = { version = "0.12", default-features = false }
+prost = { version = "0.13.3", default-features = false }
 safe-regex = { version = "0.2.5", default-features = false }
 # proc-macro2 to unbreak docs.rs build, see GH#56
 proc-macro2 = { version = "0.1", default-features = false }
@@ -87,15 +87,15 @@ scale-info = { version = "2.1.2", default-features = false, features = ["derive"
 anyhow = { version = "1", default-features = false }
 
 [dependencies.tendermint]
-version = "0.34.0"
+version = "0.40.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.34.0"
+version = "0.40.0"
 default-features = false
 
 [dependencies.tendermint-testgen]
-version = "0.34.0"
+version = "0.40.0"
 optional = true
 default-features = false
 

--- a/crates/ibc-types-core-channel/src/events/channel.rs
+++ b/crates/ibc-types-core-channel/src/events/channel.rs
@@ -1,7 +1,7 @@
-use alloc::borrow::ToOwned;
 use ibc_types_core_connection::ConnectionId;
 use tendermint::abci::{Event, TypedEvent};
 
+use crate::prelude::*;
 use crate::{ChannelId, PortId, Version};
 
 use super::Error;
@@ -56,23 +56,32 @@ impl TryFrom<Event> for OpenInit {
         let mut version = None;
 
         for attr in event.attributes {
-            match attr.key.as_ref() {
-                "port_id" => {
-                    port_id = Some(PortId(attr.value));
+            match attr.key_bytes() {
+                b"port_id" => {
+                    port_id = Some(PortId(String::from_utf8_lossy(attr.value_bytes()).into()));
                 }
-                "channel_id" => {
-                    channel_id = Some(ChannelId(attr.value));
+                b"channel_id" => {
+                    channel_id = Some(ChannelId(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                "counterparty_port_id" => {
-                    counterparty_port_id = Some(PortId(attr.value));
+                b"counterparty_port_id" => {
+                    counterparty_port_id =
+                        Some(PortId(String::from_utf8_lossy(attr.value_bytes()).into()));
                 }
-                "connection_id" => {
-                    connection_id = Some(ConnectionId(attr.value));
+                b"connection_id" => {
+                    connection_id = Some(ConnectionId(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                "version" => {
-                    version = Some(Version(attr.value));
+                b"version" => {
+                    version = Some(Version(String::from_utf8_lossy(attr.value_bytes()).into()));
                 }
-                unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
+                unknown => {
+                    return Err(Error::UnexpectedAttribute(
+                        String::from_utf8_lossy(unknown).into(),
+                    ))
+                }
             }
         }
 
@@ -136,26 +145,37 @@ impl TryFrom<Event> for OpenTry {
         let mut version = None;
 
         for attr in event.attributes {
-            match attr.key.as_ref() {
-                "port_id" => {
-                    port_id = Some(PortId(attr.value));
+            match attr.key_bytes() {
+                b"port_id" => {
+                    port_id = Some(PortId(String::from_utf8_lossy(attr.value_bytes()).into()));
                 }
-                "channel_id" => {
-                    channel_id = Some(ChannelId(attr.value));
+                b"channel_id" => {
+                    channel_id = Some(ChannelId(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                "counterparty_port_id" => {
-                    counterparty_port_id = Some(PortId(attr.value));
+                b"counterparty_port_id" => {
+                    counterparty_port_id =
+                        Some(PortId(String::from_utf8_lossy(attr.value_bytes()).into()));
                 }
-                "counterparty_channel_id" => {
-                    counterparty_channel_id = Some(ChannelId(attr.value));
+                b"counterparty_channel_id" => {
+                    counterparty_channel_id = Some(ChannelId(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                "connection_id" => {
-                    connection_id = Some(ConnectionId(attr.value));
+                b"connection_id" => {
+                    connection_id = Some(ConnectionId(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                "version" => {
-                    version = Some(Version(attr.value));
+                b"version" => {
+                    version = Some(Version(String::from_utf8_lossy(attr.value_bytes()).into()));
                 }
-                unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
+                unknown => {
+                    return Err(Error::UnexpectedAttribute(
+                        String::from_utf8_lossy(unknown).into(),
+                    ))
+                }
             }
         }
 
@@ -218,23 +238,34 @@ impl TryFrom<Event> for OpenAck {
         let mut connection_id = None;
 
         for attr in event.attributes {
-            match attr.key.as_ref() {
-                "port_id" => {
-                    port_id = Some(PortId(attr.value));
+            match attr.key_bytes() {
+                b"port_id" => {
+                    port_id = Some(PortId(String::from_utf8_lossy(attr.value_bytes()).into()));
                 }
-                "channel_id" => {
-                    channel_id = Some(ChannelId(attr.value));
+                b"channel_id" => {
+                    channel_id = Some(ChannelId(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                "counterparty_port_id" => {
-                    counterparty_port_id = Some(PortId(attr.value));
+                b"counterparty_port_id" => {
+                    counterparty_port_id =
+                        Some(PortId(String::from_utf8_lossy(attr.value_bytes()).into()));
                 }
-                "counterparty_channel_id" => {
-                    counterparty_channel_id = Some(ChannelId(attr.value));
+                b"counterparty_channel_id" => {
+                    counterparty_channel_id = Some(ChannelId(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                "connection_id" => {
-                    connection_id = Some(ConnectionId(attr.value));
+                b"connection_id" => {
+                    connection_id = Some(ConnectionId(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
+                unknown => {
+                    return Err(Error::UnexpectedAttribute(
+                        String::from_utf8_lossy(unknown).into(),
+                    ))
+                }
             }
         }
 
@@ -296,23 +327,34 @@ impl TryFrom<Event> for OpenConfirm {
         let mut connection_id = None;
 
         for attr in event.attributes {
-            match attr.key.as_ref() {
-                "port_id" => {
-                    port_id = Some(PortId(attr.value));
+            match attr.key_bytes() {
+                b"port_id" => {
+                    port_id = Some(PortId(String::from_utf8_lossy(attr.value_bytes()).into()));
                 }
-                "channel_id" => {
-                    channel_id = Some(ChannelId(attr.value));
+                b"channel_id" => {
+                    channel_id = Some(ChannelId(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                "counterparty_port_id" => {
-                    counterparty_port_id = Some(PortId(attr.value));
+                b"counterparty_port_id" => {
+                    counterparty_port_id =
+                        Some(PortId(String::from_utf8_lossy(attr.value_bytes()).into()));
                 }
-                "counterparty_channel_id" => {
-                    counterparty_channel_id = Some(ChannelId(attr.value));
+                b"counterparty_channel_id" => {
+                    counterparty_channel_id = Some(ChannelId(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                "connection_id" => {
-                    connection_id = Some(ConnectionId(attr.value));
+                b"connection_id" => {
+                    connection_id = Some(ConnectionId(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
+                unknown => {
+                    return Err(Error::UnexpectedAttribute(
+                        String::from_utf8_lossy(unknown).into(),
+                    ))
+                }
             }
         }
 
@@ -374,23 +416,34 @@ impl TryFrom<Event> for CloseInit {
         let mut connection_id = None;
 
         for attr in event.attributes {
-            match attr.key.as_ref() {
-                "port_id" => {
-                    port_id = Some(PortId(attr.value));
+            match attr.key_bytes() {
+                b"port_id" => {
+                    port_id = Some(PortId(String::from_utf8_lossy(attr.value_bytes()).into()));
                 }
-                "channel_id" => {
-                    channel_id = Some(ChannelId(attr.value));
+                b"channel_id" => {
+                    channel_id = Some(ChannelId(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                "counterparty_port_id" => {
-                    counterparty_port_id = Some(PortId(attr.value));
+                b"counterparty_port_id" => {
+                    counterparty_port_id =
+                        Some(PortId(String::from_utf8_lossy(attr.value_bytes()).into()));
                 }
-                "counterparty_channel_id" => {
-                    counterparty_channel_id = Some(ChannelId(attr.value));
+                b"counterparty_channel_id" => {
+                    counterparty_channel_id = Some(ChannelId(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                "connection_id" => {
-                    connection_id = Some(ConnectionId(attr.value));
+                b"connection_id" => {
+                    connection_id = Some(ConnectionId(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
+                unknown => {
+                    return Err(Error::UnexpectedAttribute(
+                        String::from_utf8_lossy(unknown).into(),
+                    ))
+                }
             }
         }
 
@@ -452,23 +505,34 @@ impl TryFrom<Event> for CloseConfirm {
         let mut connection_id = None;
 
         for attr in event.attributes {
-            match attr.key.as_ref() {
-                "port_id" => {
-                    port_id = Some(PortId(attr.value));
+            match attr.key_bytes() {
+                b"port_id" => {
+                    port_id = Some(PortId(String::from_utf8_lossy(attr.value_bytes()).into()));
                 }
-                "channel_id" => {
-                    channel_id = Some(ChannelId(attr.value));
+                b"channel_id" => {
+                    channel_id = Some(ChannelId(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                "counterparty_port_id" => {
-                    counterparty_port_id = Some(PortId(attr.value));
+                b"counterparty_port_id" => {
+                    counterparty_port_id =
+                        Some(PortId(String::from_utf8_lossy(attr.value_bytes()).into()));
                 }
-                "counterparty_channel_id" => {
-                    counterparty_channel_id = Some(ChannelId(attr.value));
+                b"counterparty_channel_id" => {
+                    counterparty_channel_id = Some(ChannelId(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                "connection_id" => {
-                    connection_id = Some(ConnectionId(attr.value));
+                b"connection_id" => {
+                    connection_id = Some(ConnectionId(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
+                unknown => {
+                    return Err(Error::UnexpectedAttribute(
+                        String::from_utf8_lossy(unknown).into(),
+                    ))
+                }
             }
         }
 

--- a/crates/ibc-types-core-channel/src/events/tests.rs
+++ b/crates/ibc-types-core-channel/src/events/tests.rs
@@ -135,12 +135,18 @@ fn ibc_to_abci_channel_events() {
         assert_eq!(t.kind, t.event.kind);
         assert_eq!(t.expected_keys.len(), t.event.attributes.len());
         for (i, e) in t.event.attributes.iter().enumerate() {
-            assert_eq!(e.key, t.expected_keys[i], "key mismatch for {:?}", t.kind,);
+            assert_eq!(
+                e.key_bytes(),
+                t.expected_keys[i].as_bytes(),
+                "key mismatch for {:?}",
+                t.kind,
+            );
         }
         assert_eq!(t.expected_values.len(), t.event.attributes.len());
         for (i, e) in t.event.attributes.iter().enumerate() {
             assert_eq!(
-                e.value, t.expected_values[i],
+                e.value_bytes(),
+                t.expected_values[i].as_bytes(),
                 "value mismatch for {:?}",
                 t.kind,
             );

--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -54,14 +54,14 @@ bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 displaydoc = { version = "0.2", default-features = false }
-ibc-proto = { version = "0.42.2", default-features = false }
+ibc-proto = { version = "0.51.1", default-features = false }
 ibc-types-domain-type = { version = "0.14.1", path = "../ibc-types-domain-type", default-features = false }
 ibc-types-identifier = { version = "0.14.1", path = "../ibc-types-identifier", default-features = false }
 ibc-types-timestamp = { version = "0.14.1", path = "../ibc-types-timestamp", default-features = false }
-ics23 = { version = "0.11.3", default-features = false, features = ["host-functions"] }
+ics23 = { version = "0.12.0", default-features = false, features = ["host-functions"] }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
-prost = { version = "0.12", default-features = false }
+prost = { version = "0.13.3", default-features = false }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }
@@ -72,11 +72,11 @@ time = { version = "0.3", default-features = false }
 anyhow = { version = "1", default-features = false }
 
 [dependencies.tendermint]
-version = "0.34.0"
+version = "0.40.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.34.0"
+version = "0.40.0"
 default-features = false
 
 [dev-dependencies]

--- a/crates/ibc-types-core-client/src/events.rs
+++ b/crates/ibc-types-core-client/src/events.rs
@@ -95,21 +95,30 @@ impl TryFrom<Event> for CreateClient {
         let mut consensus_height = None;
 
         for attr in event.attributes {
-            match attr.key.as_ref() {
-                "client_id" => {
-                    client_id = Some(ClientId(attr.value));
+            match attr.key_bytes() {
+                b"client_id" => {
+                    client_id = Some(ClientId(String::from_utf8_lossy(attr.value_bytes()).into()));
                 }
-                "client_type" => {
-                    client_type = Some(ClientType(attr.value));
+                b"client_type" => {
+                    client_type = Some(ClientType(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                "consensus_height" => {
-                    consensus_height =
-                        Some(attr.value.parse().map_err(|e| Error::ParseHeight {
-                            key: "consensus_height",
-                            e,
-                        })?);
+                b"consensus_height" => {
+                    consensus_height = Some(
+                        String::from_utf8_lossy(attr.value_bytes())
+                            .parse()
+                            .map_err(|e| Error::ParseHeight {
+                                key: "consensus_height",
+                                e,
+                            })?,
+                    );
                 }
-                unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
+                unknown => {
+                    return Err(Error::UnexpectedAttribute(
+                        String::from_utf8_lossy(unknown).into(),
+                    ))
+                }
             }
         }
 
@@ -167,27 +176,36 @@ impl TryFrom<Event> for UpdateClient {
         let mut header = None;
 
         for attr in value.attributes {
-            match attr.key.as_ref() {
-                "client_id" => {
-                    client_id = Some(ClientId(attr.value));
+            match attr.key_bytes() {
+                b"client_id" => {
+                    client_id = Some(ClientId(String::from_utf8_lossy(attr.value_bytes()).into()));
                 }
-                "client_type" => {
-                    client_type = Some(ClientType(attr.value));
+                b"client_type" => {
+                    client_type = Some(ClientType(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                "consensus_height" => {
-                    consensus_height =
-                        Some(attr.value.parse().map_err(|e| Error::ParseHeight {
-                            key: "consensus_height",
-                            e,
-                        })?);
+                b"consensus_height" => {
+                    consensus_height = Some(
+                        String::from_utf8_lossy(attr.value_bytes())
+                            .parse()
+                            .map_err(|e| Error::ParseHeight {
+                                key: "consensus_height",
+                                e,
+                            })?,
+                    );
                 }
-                "header" => {
+                b"header" => {
                     header = Some(
-                        hex::decode(attr.value)
+                        hex::decode(attr.value_bytes())
                             .map_err(|e| Error::ParseHex { key: "header", e })?,
                     );
                 }
-                unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
+                unknown => {
+                    return Err(Error::UnexpectedAttribute(
+                        String::from_utf8_lossy(unknown).into(),
+                    ))
+                }
             }
         }
 
@@ -238,14 +256,20 @@ impl TryFrom<Event> for ClientMisbehaviour {
         let mut client_type = None;
 
         for attr in value.attributes {
-            match attr.key.as_ref() {
-                "client_id" => {
-                    client_id = Some(ClientId(attr.value));
+            match attr.key_bytes() {
+                b"client_id" => {
+                    client_id = Some(ClientId(String::from_utf8_lossy(attr.value_bytes()).into()));
                 }
-                "client_type" => {
-                    client_type = Some(ClientType(attr.value));
+                b"client_type" => {
+                    client_type = Some(ClientType(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
+                unknown => {
+                    return Err(Error::UnexpectedAttribute(
+                        String::from_utf8_lossy(unknown).into(),
+                    ))
+                }
             }
         }
 
@@ -295,21 +319,30 @@ impl TryFrom<Event> for UpgradeClient {
         let mut consensus_height = None;
 
         for attr in value.attributes {
-            match attr.key.as_ref() {
-                "client_id" => {
-                    client_id = Some(ClientId(attr.value));
+            match attr.key_bytes() {
+                b"client_id" => {
+                    client_id = Some(ClientId(String::from_utf8_lossy(attr.value_bytes()).into()));
                 }
-                "client_type" => {
-                    client_type = Some(ClientType(attr.value));
+                b"client_type" => {
+                    client_type = Some(ClientType(
+                        String::from_utf8_lossy(attr.value_bytes()).into(),
+                    ));
                 }
-                "consensus_height" => {
-                    consensus_height =
-                        Some(attr.value.parse().map_err(|e| Error::ParseHeight {
-                            key: "consensus_height",
-                            e,
-                        })?);
+                b"consensus_height" => {
+                    consensus_height = Some(
+                        String::from_utf8_lossy(attr.value_bytes())
+                            .parse()
+                            .map_err(|e| Error::ParseHeight {
+                                key: "consensus_height",
+                                e,
+                            })?,
+                    );
                 }
-                unknown => return Err(Error::UnexpectedAttribute(unknown.to_owned())),
+                unknown => {
+                    return Err(Error::UnexpectedAttribute(
+                        String::from_utf8_lossy(unknown).into(),
+                    ))
+                }
             }
         }
 

--- a/crates/ibc-types-core-commitment/Cargo.toml
+++ b/crates/ibc-types-core-commitment/Cargo.toml
@@ -59,15 +59,15 @@ ibc-types-timestamp = { version = "0.14.1", path = "../ibc-types-timestamp", def
 ibc-types-identifier = { version = "0.14.1", path = "../ibc-types-identifier", default-features = false }
 ibc-types-domain-type = { version = "0.14.1", path = "../ibc-types-domain-type", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.42.2", default-features = false }
-ics23 = { version = "0.11.3", default-features = false, features = ["host-functions"] }
+ibc-proto = { version = "0.51.1", default-features = false }
+ics23 = { version = "0.12.0", default-features = false, features = ["host-functions"] }
 time = { version = "0.3", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 serde_json = { version = "1", default-features = false, optional = true }
 erased-serde = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
 tracing = { version = "0.1.36", default-features = false }
-prost = { version = "0.12", default-features = false }
+prost = { version = "0.13.3", default-features = false }
 bytes = { version = "1.2.1", default-features = false }
 safe-regex = { version = "0.2.5", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false }
@@ -89,20 +89,20 @@ anyhow = "1"
 hex = { version = "0.4.3", default-features = false }
 
 [dependencies.tendermint]
-version = "0.34.0"
+version = "0.40.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.34.0"
+version = "0.40.0"
 default-features = false
 
 [dependencies.tendermint-light-client-verifier]
-version = "0.34.0"
+version = "0.40.0"
 default-features = false
 features = ["rust-crypto"]
 
 [dependencies.tendermint-testgen]
-version = "0.34.0"
+version = "0.40.0"
 optional = true
 default-features = false
 
@@ -111,8 +111,8 @@ env_logger = "0.10.0"
 rstest = "0.16.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
 test-log = { version = "0.2.10", features = ["trace"] }
-tendermint-rpc = { version = "0.34.0", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { version = "0.34.0" } # Needed for generating (synthetic) light blocks.
+tendermint-rpc = { version = "0.40.0", features = ["http-client", "websocket-client"] }
+tendermint-testgen = { version = "0.40.0" } # Needed for generating (synthetic) light blocks.
 parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }
 

--- a/crates/ibc-types-core-connection/Cargo.toml
+++ b/crates/ibc-types-core-connection/Cargo.toml
@@ -61,12 +61,12 @@ bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 displaydoc = { version = "0.2", default-features = false }
-ibc-proto = { version = "0.42.2", default-features = false }
-ics23 = { version = "0.11.3", default-features = false, features = ["host-functions"] }
+ibc-proto = { version = "0.51.1", default-features = false }
+ics23 = { version = "0.12.0", default-features = false, features = ["host-functions"] }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
 parking_lot = { version = "0.12.1", default-features = false, optional = true }
-prost = { version = "0.12", default-features = false }
+prost = { version = "0.13.3", default-features = false }
 safe-regex = { version = "0.2.5", default-features = false }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
@@ -78,15 +78,15 @@ time = { version = "0.3", default-features = false }
 anyhow = { version = "1", default-features = false }
 
 [dependencies.tendermint]
-version = "0.34.0"
+version = "0.40.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.34.0"
+version = "0.40.0"
 default-features = false
 
 [dependencies.tendermint-testgen]
-version = "0.34.0"
+version = "0.40.0"
 optional = true
 default-features = false
 

--- a/crates/ibc-types-domain-type/Cargo.toml
+++ b/crates/ibc-types-domain-type/Cargo.toml
@@ -20,5 +20,5 @@ all-features = true
 
 [dependencies]
 anyhow = { version = "1", default-features = false }
-prost = { version = "0.12", default-features = false }
+prost = { version = "0.13.3", default-features = false }
 bytes = { version = "1.2.1", default-features = false }

--- a/crates/ibc-types-identifier/Cargo.toml
+++ b/crates/ibc-types-identifier/Cargo.toml
@@ -47,7 +47,7 @@ parking_lot = { version = "0.12.1", default-features = false, optional = true }
 cfg-if = { version = "1.0.0", optional = true }
 
 [dependencies.tendermint-testgen]
-version = "0.33"
+version = "0.40.0"
 optional = true
 default-features = false
 

--- a/crates/ibc-types-lightclients-tendermint/Cargo.toml
+++ b/crates/ibc-types-lightclients-tendermint/Cargo.toml
@@ -63,15 +63,15 @@ ibc-types-core-client = { version = "0.14.1", path = "../ibc-types-core-client",
 ibc-types-core-connection = { version = "0.14.1", path = "../ibc-types-core-connection", default-features = false }
 ibc-types-core-commitment = { version = "0.14.1", path = "../ibc-types-core-commitment", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.42.2", default-features = false }
-ics23 = { version = "0.11.3", default-features = false, features = ["host-functions"] }
+ibc-proto = { version = "0.51.1", default-features = false }
+ics23 = { version = "0.12.0", default-features = false, features = ["host-functions"] }
 time = { version = "0.3", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 serde_json = { version = "1", default-features = false, optional = true }
 erased-serde = { version = "0.3", default-features = false, features = ["alloc"], optional = true }
 tracing = { version = "0.1.36", default-features = false }
-prost = { version = "0.12", default-features = false }
+prost = { version = "0.13.3", default-features = false }
 bytes = { version = "1.2.1", default-features = false }
 safe-regex = { version = "0.2.5", default-features = false }
 subtle-encoding = { version = "0.5", default-features = false }
@@ -92,20 +92,20 @@ cfg-if = { version = "1.0.0", optional = true }
 anyhow = { version = "1", default-features = false }
 
 [dependencies.tendermint]
-version = "0.34.0"
+version = "0.40.0"
 default-features = false
 
 [dependencies.tendermint-proto]
-version = "0.34.0"
+version = "0.40.0"
 default-features = false
 
 [dependencies.tendermint-light-client-verifier]
-version = "0.34.0"
+version = "0.40.0"
 default-features = false
 features = ["rust-crypto"]
 
 [dependencies.tendermint-testgen]
-version = "0.34.0"
+version = "0.40.0"
 optional = true
 default-features = false
 
@@ -114,8 +114,8 @@ env_logger = "0.10.0"
 rstest = "0.16.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
 test-log = { version = "0.2.10", features = ["trace"] }
-tendermint-rpc = { version = "0.34.0", features = ["http-client", "websocket-client"] }
-tendermint-testgen = { version = "0.34.0" } # Needed for generating (synthetic) light blocks.
+tendermint-rpc = { version = "0.40.0", features = ["http-client", "websocket-client"] }
+tendermint-testgen = { version = "0.40.0" } # Needed for generating (synthetic) light blocks.
 parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }
 

--- a/crates/ibc-types-lightclients-tendermint/src/error.rs
+++ b/crates/ibc-types-lightclients-tendermint/src/error.rs
@@ -135,6 +135,12 @@ pub enum Error {
     },
     /// invalid raw client id: `{client_id}`
     InvalidRawClientId { client_id: String },
+    /// can't map `{field}` to its wire format: `{reason}`
+    DurationTooLarge {
+        field: &'static str,
+        // XXX: tendermint_proto::google::protobuf::duration::DurationError is behind a private module
+        reason: String,
+    },
 }
 
 #[cfg(feature = "std")]

--- a/crates/ibc-types-path/Cargo.toml
+++ b/crates/ibc-types-path/Cargo.toml
@@ -56,16 +56,16 @@ displaydoc = { version = "0.2", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
 parking_lot = { version = "0.12.1", default-features = false, optional = true }
-prost = { version = "0.12", default-features = false }
+prost = { version = "0.13.3", default-features = false }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }
 serde_json = { version = "1", default-features = false, optional = true }
 subtle-encoding = { version = "0.5", default-features = false }
 time = { version = "0.3", default-features = false }
-tendermint = { version = "0.34.0", default-features = false }
-tendermint-proto = { version = "0.34.0", default-features = false }
-tendermint-testgen = { version = "0.34.0", default-features = false, optional = true }
+tendermint = { version = "0.40.0", default-features = false }
+tendermint-proto = { version = "0.40.0", default-features = false }
+tendermint-testgen = { version = "0.40.0", default-features = false, optional = true }
 
 [dev-dependencies]
 cfg-if = { version = "1.0.0" }

--- a/crates/ibc-types-timestamp/Cargo.toml
+++ b/crates/ibc-types-timestamp/Cargo.toml
@@ -48,16 +48,16 @@ displaydoc = { version = "0.2", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
 parking_lot = { version = "0.12.1", default-features = false, optional = true }
-prost = { version = "0.12", default-features = false }
+prost = { version = "0.13.3", default-features = false }
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"], optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }
 serde_json = { version = "1", default-features = false, optional = true }
 subtle-encoding = { version = "0.5", default-features = false }
 time = { version = "0.3", default-features = false }
-tendermint = { version = "0.34.0", default-features = false }
-tendermint-proto = { version = "0.34.0", default-features = false }
-tendermint-testgen = { version = "0.34.0", default-features = false, optional = true }
+tendermint = { version = "0.40.0", default-features = false }
+tendermint-proto = { version = "0.40.0", default-features = false }
+tendermint-testgen = { version = "0.40.0", default-features = false, optional = true }
 
 [dev-dependencies]
 cfg-if = { version = "1.0.0" }

--- a/crates/ibc-types-transfer/Cargo.toml
+++ b/crates/ibc-types-transfer/Cargo.toml
@@ -47,7 +47,7 @@ parking_lot = { version = "0.12.1", default-features = false, optional = true }
 cfg-if = { version = "1.0.0", optional = true }
 
 [dependencies.tendermint-testgen]
-version = "0.33"
+version = "0.40.0"
 optional = true
 default-features = false
 


### PR DESCRIPTION
Updates the following dependencies:
+ ibc-proto: 0.42.2 -> 0.51.1
+ ics23: 0.11.3 -> 0.12.0
+ prost: 0.12.0 -> 0.13.3
+ tendermint: 0.34.0 -> 0.40.0
+ tendermint-light-client-verifier: 0.34.0 -> 0.40.0
+ tendermint-proto: 0.34.0 -> 0.40.0
+ tendermint-rpc: 0.34.0 -> 0.40.0
+ tendermint-testgen: 0.34.0 -> 0.40.0

The bump to the latest tendermint version required bumping prost, which in turns required updates of ibc-proto and ics23 (where I opted for their latest releases, respectively).

The two larger changes are:

1. From tendermint@v0.40.0 onward conversions between `core::time::Duration` and `protobuf.google.Duration` are now fallible. I introduced a newtype wrapper `CometBftDuration` to restore the previous behavior saturating at `i64::MAX` (for seconds) and `i32::MAX` (for nanos), respectively.
2. From `tendermint@v0.36.0` onward [`tendermint::abci::EventAttribute`](https://docs.rs/tendermint/0.36.0/tendermint/abci/enum.EventAttribute.html) became an enum with variants `V037` and `V034`, and introduced the fallible accessors `EventAttribute::key_str` and `EventAttribute::value_str`, in addition to the infallible `EventAttribute::key_bytes` and `EventAttribute::value_bytes`. This required changes in many `TryFrom<Event>` impls that would previously match on `&str` keys and directly move (or parse) `String` values. I chose to avoid extra error handling, instead matching on byte-string using `value_bytes()` (e.g. now `b"packet_src_channel" => {}` instead of the previous `"packet_src_channel" => {}`), and relying on `String::from_utf8_lossy` for the values.