### PR TITLE
bump ibc-proto@v0.52.0, ibc-types@v0.16

### DIFF
--- a/crates/ibc-types-core-channel/Cargo.toml
+++ b/crates/ibc-types-core-channel/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name         = "ibc-types-core-channel"
-version      = "0.15.1"
+version      = "0.16.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
 keywords     = ["blockchain", "consensus", "cosmos", "ibc", "tendermint"]
 repository   = "https://github.com/penumbra-zone/ibc-types"
 authors      = ["Penumbra Labs <team@penumbralabs.xyz"]
-rust-version = "1.60"
+rust-version = "1.75"
 description  = """
     Data types for the Inter-Blockchain Communication (IBC) protocol.
     This crate defines common data structures that can be reused by different IBC implementations or ecosystem tooling.
@@ -53,14 +53,14 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-ibc-types-core-client = { version = "0.15.1", path = "../ibc-types-core-client", default-features = false }
-ibc-types-core-connection = { version = "0.15.1", path = "../ibc-types-core-connection", default-features = false }
-ibc-types-core-commitment = { version = "0.15.1", path = "../ibc-types-core-commitment", default-features = false }
-ibc-types-domain-type = { version = "0.15.1", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-identifier = { version = "0.15.1", path = "../ibc-types-identifier", default-features = false }
-ibc-types-timestamp = { version = "0.15.1", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-core-client = { version = "0.16.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-core-connection = { version = "0.16.0", path = "../ibc-types-core-connection", default-features = false }
+ibc-types-core-commitment = { version = "0.16.0", path = "../ibc-types-core-commitment", default-features = false }
+ibc-types-domain-type = { version = "0.16.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-identifier = { version = "0.16.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-timestamp = { version = "0.16.0", path = "../ibc-types-timestamp", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.51.1", default-features = false }
+ibc-proto = { version = "0.52.0", default-features = false }
 ## for borsh encode or decode
 borsh = {version = "0.10.0", default-features = false, optional = true }
 bytes = { version = "1.2.1", default-features = false }
@@ -102,6 +102,6 @@ default-features = false
 [dev-dependencies]
 cfg-if = { version = "1.0.0" }
 env_logger = "0.10.0"
-ibc-types-core-client = { version = "0.15.1", path = "../ibc-types-core-client", features = ["mocks"] }
+ibc-types-core-client = { version = "0.16.0", path = "../ibc-types-core-client", features = ["mocks"] }
 test-log = { version = "0.2.10", features = ["trace"] }
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}

--- a/crates/ibc-types-core-client/Cargo.toml
+++ b/crates/ibc-types-core-client/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name         = "ibc-types-core-client"
-version      = "0.15.1"
+version      = "0.16.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
 keywords     = ["blockchain", "consensus", "cosmos", "ibc", "tendermint"]
 repository   = "https://github.com/penumbra-zone/ibc-types"
 authors      = ["Penumbra Labs <team@penumbralabs.xyz"]
-rust-version = "1.60"
+rust-version = "1.75"
 description  = """
     Data types for the Inter-Blockchain Communication (IBC) protocol.
     This crate defines common data structures that can be reused by different IBC implementations or ecosystem tooling.
@@ -54,10 +54,10 @@ bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 displaydoc = { version = "0.2", default-features = false }
-ibc-proto = { version = "0.51.1", default-features = false }
-ibc-types-domain-type = { version = "0.15.1", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-identifier = { version = "0.15.1", path = "../ibc-types-identifier", default-features = false }
-ibc-types-timestamp = { version = "0.15.1", path = "../ibc-types-timestamp", default-features = false }
+ibc-proto = { version = "0.52.0", default-features = false }
+ibc-types-domain-type = { version = "0.16.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-identifier = { version = "0.16.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-timestamp = { version = "0.16.0", path = "../ibc-types-timestamp", default-features = false }
 ics23 = { version = "0.12.0", default-features = false, features = ["host-functions"] }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }

--- a/crates/ibc-types-core-commitment/Cargo.toml
+++ b/crates/ibc-types-core-commitment/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name         = "ibc-types-core-commitment"
-version      = "0.15.1"
+version      = "0.16.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
 keywords     = ["blockchain", "consensus", "cosmos", "ibc", "tendermint"]
 repository   = "https://github.com/penumbra-zone/ibc-types"
 authors      = ["Penumbra Labs <team@penumbralabs.xyz"]
-rust-version = "1.60"
+rust-version = "1.75"
 description  = """
     Data types for the Inter-Blockchain Communication (IBC) protocol.
     This crate defines common data structures that can be reused by different IBC implementations or ecosystem tooling.
@@ -59,7 +59,7 @@ ibc-types-timestamp = { version = "0.15.1", path = "../ibc-types-timestamp", def
 ibc-types-identifier = { version = "0.15.1", path = "../ibc-types-identifier", default-features = false }
 ibc-types-domain-type = { version = "0.15.1", path = "../ibc-types-domain-type", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.51.1", default-features = false }
+ibc-proto = { version = "0.52.0", default-features = false }
 ics23 = { version = "0.12.0", default-features = false, features = ["host-functions"] }
 time = { version = "0.3", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }

--- a/crates/ibc-types-core-connection/Cargo.toml
+++ b/crates/ibc-types-core-connection/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name         = "ibc-types-core-connection"
-version      = "0.15.1"
+version      = "0.16.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
 keywords     = ["blockchain", "consensus", "cosmos", "ibc", "tendermint"]
 repository   = "https://github.com/penumbra-zone/ibc-types"
 authors      = ["Penumbra Labs <team@penumbralabs.xyz"]
-rust-version = "1.60"
+rust-version = "1.75"
 description  = """
     Data types for the Inter-Blockchain Communication (IBC) protocol.
     This crate defines common data structures that can be reused by different IBC implementations or ecosystem tooling.
@@ -51,17 +51,17 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-ibc-types-timestamp = { version = "0.15.1", path = "../ibc-types-timestamp", default-features = false }
-ibc-types-core-commitment = { version = "0.15.1", path = "../ibc-types-core-commitment", default-features = false }
-ibc-types-identifier = { version = "0.15.1", path = "../ibc-types-identifier", default-features = false }
-ibc-types-domain-type = { version = "0.15.1", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-core-client = { version = "0.15.1", path = "../ibc-types-core-client", default-features = false }
+ibc-types-timestamp = { version = "0.16.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-core-commitment = { version = "0.16.0", path = "../ibc-types-core-commitment", default-features = false }
+ibc-types-identifier = { version = "0.16.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-domain-type = { version = "0.16.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-core-client = { version = "0.16.0", path = "../ibc-types-core-client", default-features = false }
 borsh = {version = "0.10.0", default-features = false, optional = true }
 bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
 displaydoc = { version = "0.2", default-features = false }
-ibc-proto = { version = "0.51.1", default-features = false }
+ibc-proto = { version = "0.52.0", default-features = false }
 ics23 = { version = "0.12.0", default-features = false, features = ["host-functions"] }
 num-traits = { version = "0.2.15", default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["full"], optional = true }
@@ -95,5 +95,5 @@ env_logger = "0.10.0"
 tracing-subscriber = { version = "0.3.14", features = ["fmt", "env-filter", "json"]}
 test-log = { version = "0.2.10", features = ["trace"] }
 cfg-if = { version = "1.0.0" }
-ibc-types-core-client = { version = "0.15.1", path = "../ibc-types-core-client", features = ["mocks"] }
+ibc-types-core-client = { version = "0.16.0", path = "../ibc-types-core-client", features = ["mocks"] }
 tracing = { version = "0.1.36", default-features = false }

--- a/crates/ibc-types-lightclients-tendermint/Cargo.toml
+++ b/crates/ibc-types-lightclients-tendermint/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name         = "ibc-types-lightclients-tendermint"
-version      = "0.15.1"
+version      = "0.16.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
 keywords     = ["blockchain", "consensus", "cosmos", "ibc", "tendermint"]
 repository   = "https://github.com/penumbra-zone/ibc-types"
 authors      = ["Penumbra Labs <team@penumbralabs.xyz"]
-rust-version = "1.60"
+rust-version = "1.75"
 description  = """
     Data types for the Inter-Blockchain Communication (IBC) protocol.
     This crate defines common data structures that can be reused by different IBC implementations or ecosystem tooling.
@@ -56,14 +56,15 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-ibc-types-timestamp = { version = "0.15.1", path = "../ibc-types-timestamp", default-features = false }
-ibc-types-identifier = { version = "0.15.1", path = "../ibc-types-identifier", default-features = false }
-ibc-types-domain-type = { version = "0.15.1", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-core-client = { version = "0.15.1", path = "../ibc-types-core-client", default-features = false }
-ibc-types-core-connection = { version = "0.15.1", path = "../ibc-types-core-connection", default-features = false }
-ibc-types-core-commitment = { version = "0.15.1", path = "../ibc-types-core-commitment", default-features = false }
+ibc-types-timestamp = { version = "0.16.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-identifier = { version = "0.16.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-domain-type = { version = "0.16.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-core-client = { version = "0.16.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-core-connection = { version = "0.16.0", path = "../ibc-types-core-connection", default-features = false }
+ibc-types-core-commitment = { version = "0.16.0", path = "../ibc-types-core-commitment", default-features = false }
+
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
-ibc-proto = { version = "0.51.1", default-features = false }
+ibc-proto = { version = "0.52.0", default-features = false }
 ics23 = { version = "0.12.0", default-features = false, features = ["host-functions"] }
 time = { version = "0.3", default-features = false }
 serde_derive = { version = "1.0.104", default-features = false, optional = true }
@@ -118,5 +119,4 @@ tendermint-rpc = { version = "0.40.3", features = ["http-client", "websocket-cli
 tendermint-testgen = { version = "0.40.3" } # Needed for generating (synthetic) light blocks.
 parking_lot = { version = "0.12.1" }
 cfg-if = { version = "1.0.0" }
-
-ibc-types-core-client = { version = "0.15.1", path = "../ibc-types-core-client", features = ["mocks"] }
+ibc-types-core-client = { version = "0.16.0", path = "../ibc-types-core-client", features = ["mocks"] }

--- a/crates/ibc-types-path/Cargo.toml
+++ b/crates/ibc-types-path/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name         = "ibc-types-path"
-version      = "0.15.1"
+version      = "0.16.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
 keywords     = ["blockchain", "consensus", "cosmos", "ibc", "tendermint"]
 repository   = "https://github.com/penumbra-zone/ibc-types"
 authors      = ["Penumbra Labs <team@penumbralabs.xyz"]
-rust-version = "1.60"
+rust-version = "1.75"
 description  = """
     Data types for the Inter-Blockchain Communication (IBC) protocol.
     This crate defines common data structures that can be reused by different IBC implementations or ecosystem tooling.
@@ -46,9 +46,9 @@ mocks-no-std = ["cfg-if"]
 
 [dependencies]
 derive_more = { version = "0.99.17", default-features = false, features = ["from", "into", "display"] }
-ibc-types-core-client = { version = "0.15.1", path = "../ibc-types-core-client", default-features = false }
-ibc-types-core-connection = { version = "0.15.1", path = "../ibc-types-core-connection", default-features = false }
-ibc-types-core-channel = { version = "0.15.1", path = "../ibc-types-core-channel", default-features = false }
+ibc-types-core-client = { version = "0.16.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-core-connection = { version = "0.16.0", path = "../ibc-types-core-connection", default-features = false }
+ibc-types-core-channel = { version = "0.16.0", path = "../ibc-types-core-channel", default-features = false }
 borsh = {version = "0.10.0", default-features = false, optional = true }
 bytes = { version = "1.2.1", default-features = false }
 cfg-if = { version = "1.0.0", optional = true }

--- a/crates/ibc-types/Cargo.toml
+++ b/crates/ibc-types/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name         = "ibc-types"
-version      = "0.15.1"
+version      = "0.16.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"
 keywords     = ["blockchain", "consensus", "cosmos", "ibc", "tendermint"]
 repository   = "https://github.com/penumbra-zone/ibc-types"
 authors      = ["Penumbra Labs <team@penumbralabs.xyz"]
-rust-version = "1.60"
+rust-version = "1.75"
 description  = """
     Data types for the Inter-Blockchain Communication (IBC) protocol.
     This crate defines common data structures that can be reused by different IBC implementations or ecosystem tooling.
@@ -56,13 +56,13 @@ mocks = [
 ]
 
 [dependencies]
-ibc-types-timestamp = { version = "0.15.1", path = "../ibc-types-timestamp", default-features = false }
-ibc-types-identifier = { version = "0.15.1", path = "../ibc-types-identifier", default-features = false }
-ibc-types-domain-type = { version = "0.15.1", path = "../ibc-types-domain-type", default-features = false }
-ibc-types-core-client = { version = "0.15.1", path = "../ibc-types-core-client", default-features = false }
-ibc-types-core-connection = { version = "0.15.1", path = "../ibc-types-core-connection", default-features = false }
-ibc-types-core-channel = { version = "0.15.1", path = "../ibc-types-core-channel", default-features = false }
-ibc-types-core-commitment = { version = "0.15.1", path = "../ibc-types-core-commitment", default-features = false }
-ibc-types-lightclients-tendermint = { version = "0.15.1", path = "../ibc-types-lightclients-tendermint", default-features = false }
-ibc-types-path = { version = "0.15.1", path = "../ibc-types-path", default-features = false }
-ibc-types-transfer = { version = "0.15.1", path = "../ibc-types-transfer", default-features = false }
+ibc-types-timestamp = { version = "0.16.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-identifier = { version = "0.16.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-domain-type = { version = "0.16.0", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-core-client = { version = "0.16.0", path = "../ibc-types-core-client", default-features = false }
+ibc-types-core-connection = { version = "0.16.0", path = "../ibc-types-core-connection", default-features = false }
+ibc-types-core-channel = { version = "0.16.0", path = "../ibc-types-core-channel", default-features = false }
+ibc-types-core-commitment = { version = "0.16.0", path = "../ibc-types-core-commitment", default-features = false }
+ibc-types-lightclients-tendermint = { version = "0.16.0", path = "../ibc-types-lightclients-tendermint", default-features = false }
+ibc-types-path = { version = "0.16.0", path = "../ibc-types-path", default-features = false }
+ibc-types-transfer = { version = "0.16.0", path = "../ibc-types-transfer", default-features = false }


### PR DESCRIPTION
This patch bumps the recently released `ibc-proto@v0.52.0` and prepares a new release of all crates that have it as a direct or transient dependency:

+ ibc-types@v0.16.0
+ ibc-types-core-channel@v0.16.0
+ ibc-types-core-client@v0.16.0
+ ibc-types-core-commitment@v0.16.0
+ ibc-types-core-connection@v0.16.0
+ ibc-types-lightclients-tendermint@v0.16.0
+ ibc-types-path@v0.16.0

Because ibc-proto now has a msrv of rust 1.75.0 because of its dependency on tonic, I have set `rust-version = "1.75.0"` in all the aforementioned crates.

Note that this patch currently breaks with the convention of bumping all crate versions in the workspace in lock-step: some of the crates are not affected by the changes and so I have opted to not change them. If it is desired to have a lockstep release I can also do that.