### PR TITLE
ibc-types: fix missed version during rebase

### DIFF
--- a/crates/ibc-types-core-commitment/Cargo.toml
+++ b/crates/ibc-types-core-commitment/Cargo.toml
@@ -55,9 +55,9 @@ mocks = ["tendermint-testgen", "tendermint/clock", "cfg-if", "parking_lot"]
 mocks-no-std = ["cfg-if"]
 
 [dependencies]
-ibc-types-timestamp = { version = "0.15.1", path = "../ibc-types-timestamp", default-features = false }
-ibc-types-identifier = { version = "0.15.1", path = "../ibc-types-identifier", default-features = false }
-ibc-types-domain-type = { version = "0.15.1", path = "../ibc-types-domain-type", default-features = false }
+ibc-types-timestamp = { version = "0.16.0", path = "../ibc-types-timestamp", default-features = false }
+ibc-types-identifier = { version = "0.16.0", path = "../ibc-types-identifier", default-features = false }
+ibc-types-domain-type = { version = "0.16.0", path = "../ibc-types-domain-type", default-features = false }
 # Proto definitions for all IBC-related interfaces, e.g., connections or channels.
 ibc-proto = { version = "0.52.0", default-features = false }
 ics23 = { version = "0.12.0", default-features = false, features = ["host-functions"] }

--- a/crates/ibc-types-domain-type/Cargo.toml
+++ b/crates/ibc-types-domain-type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ibc-types-domain-type"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 license      = "Apache-2.0"
 publish = true

--- a/crates/ibc-types-identifier/Cargo.toml
+++ b/crates/ibc-types-identifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-identifier"
-version      = "0.15.1"
+version      = "0.16.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"

--- a/crates/ibc-types-timestamp/Cargo.toml
+++ b/crates/ibc-types-timestamp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-timestamp"
-version      = "0.15.1"
+version      = "0.16.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"

--- a/crates/ibc-types-transfer/Cargo.toml
+++ b/crates/ibc-types-transfer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name         = "ibc-types-transfer"
-version      = "0.15.1"
+version      = "0.16.0"
 edition      = "2021"
 license      = "Apache-2.0"
 readme       = "../../README.md"


### PR DESCRIPTION
Missed those during the rebase of #97, this will fix CI and let us publish 16.